### PR TITLE
add plugin boilerplate and example using the local plugin

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/example/.serverless_plugins/serverless-appsync
+++ b/example/.serverless_plugins/serverless-appsync
@@ -1,0 +1,1 @@
+../../serverless-appsync

--- a/example/handler.js
+++ b/example/handler.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports.hello = (event, context, callback) => {
+  const response = {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: 'Go Serverless v1.0! Your function executed successfully!'
+    })
+  };
+
+  callback(null, response);
+};

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -1,0 +1,14 @@
+service:
+  name: appsync-example
+  publish: false # disable auto-publishing to the Serverless platform
+
+plugins:
+  - serverless-appsync
+
+provider:
+  name: aws
+  runtime: nodejs6.10
+
+functions:
+  hello:
+    handler: handler.hello

--- a/serverless-appsync/index.js
+++ b/serverless-appsync/index.js
@@ -1,0 +1,25 @@
+'use strict';
+
+class ServerlessAppsyncPlugin {
+  constructor(serverless, options) {
+    this.serverless = serverless;
+    this.options = options;
+    this.hooks = {
+      'after:deploy:deploy': this.afterDeploy.bind(this)
+    };
+  }
+
+  afterDeploy() {
+    this.serverless.cli.log('Deploying AppSync Config');
+    // NOTE contains the parsed serverless.yml
+    console.log(this.serverless.service);
+    // NOTE returning a Promise is not required, but can be used
+    // to make sure all steps are executed before proceeding to the
+    // next step.
+    return new Promise((resolve, reject) => {
+      resolve();
+    });
+  }
+}
+
+module.exports = ServerlessAppsyncPlugin;


### PR DESCRIPTION
How to use:

```
cd example
serverless deploy
```

You will see the output `Deploying AppSync Config` and the logged service object. The example directly uses the local version of the plugin linked via a symlink on the filesystem.

This way you can develop the plugin right away with one or multiple example apps.