### PR TITLE
Tighten up deploy a bit

### DIFF
--- a/serverless-appsync-plugin/get-config.js
+++ b/serverless-appsync-plugin/get-config.js
@@ -50,6 +50,7 @@ module.exports = (config, provider, servicePath) => {
     authenticationType: config.authenticationType,
     schema: schemaContent,
     userPoolConfig: config.userPoolConfig,
+    serviceRoleArn: config.serviceRole,
     // TODO verify dataSources structure
     dataSources,
     mappingTemplates


### PR DESCRIPTION
This adds the `serviceRoleArn` var to get-config's returns,
grabs the missing `userPoolConfig`,
swaps in the `definition` key and gives it Buffer.from(the schema) in createGraphQLSchema(),
and swaps `async.whilst` for `async.until` in monitorGraphQLSchemaCreation()

