### PR TITLE
Map resolver mapping templates

### DIFF
--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -19,6 +19,7 @@ custom:
     # name:  # defaults to api
     authenticationType: AMAZON_COGNITO_USER_POOLS
     # region: # defaults to provider region
+    # mappingTemplatesLocation: # defailts to mapping-templates
     mappingTemplates:
       - dataSource: Users
         type: Query

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -19,7 +19,52 @@ custom:
     # name:  # defaults to api
     authenticationType: AMAZON_COGNITO_USER_POOLS
     # region: # defaults to provider region
-    # mappingTemplates:
+    mappingTemplates:
+      - dataSource: Users
+        type: Query
+        field: getUserInfo
+        request: "getUserInfo-request-mapping-template.txt"
+        response: "getUserInfo-response-mapping-template.txt"
+      - dataSource: Users
+        type: Query
+        field: meInfo
+        request: "meInfo-request-mapping-template.txt"
+        response: "meInfo-response-mapping-template.txt"
+      - dataSource: Tweets
+        type: User
+        field: topTweet
+        request: "topTweet-request-mapping-template.txt"
+        response: "topTweet-response-mapping-template.txt"
+      - dataSource: Tweets
+        type: User
+        field: tweets
+        request: "tweets-request-mapping-template.txt"
+        response: "tweets-response-mapping-template.txt"
+      - dataSource: Tweets
+        type: Mutation
+        field: createTweet
+        request: "createTweet-request-mapping-template.txt"
+        response: "createTweet-response-mapping-template.txt"
+      - dataSource: Tweets
+        type: Mutation
+        field: deleteTweet
+        request: "deleteTweet-request-mapping-template.txt"
+        response: "deleteTweet-response-mapping-template.txt"
+      - dataSource: Tweets
+        type: Mutation
+        field: reTweet
+        request: "reTweet-request-mapping-template.txt"
+        response: "reTweet-response-mapping-template.txt"
+      - dataSource: Tweets
+        type: Mutation
+        field: updateTweet
+        request: "updateTweet-request-mapping-template.txt"
+        response: "updateTweet-response-mapping-template.txt"
+      - dataSource: Users
+        type: Mutation
+        field: updateUserInfo
+        request: "updateUserInfo-request-mapping-template.txt"
+        response: "updateUserInfo-response-mapping-template.txt"
     # schema: # defaults schema.graphql
     serviceRole: something/something
     dataSources:

--- a/serverless-appsync-plugin/get-config.js
+++ b/serverless-appsync-plugin/get-config.js
@@ -24,18 +24,7 @@ module.exports = (config, provider, servicePath) => {
     );
   }
 
-  const mappingTemplatePath = path.join(
-    servicePath,
-    config.mappingTemplates || 'mapping-templates'
-  );
-  const fileNames = fs.readdirSync(mappingTemplatePath);
-
-  const mappingTemplates = fileNames.reduce((obj, fileName) => {
-    obj[fileName] = fs.readFileSync(path.join(mappingTemplatePath, fileName), {
-      encoding: 'utf8'
-    });
-    return obj;
-  }, {});
+  const mappingTemplates = config.mappingTemplates || []
 
   const schemaPath = path.join(servicePath, config.schema || 'schema.graphql');
   const schemaContent = fs.readFileSync(schemaPath, {

--- a/serverless-appsync-plugin/get-config.js
+++ b/serverless-appsync-plugin/get-config.js
@@ -24,6 +24,7 @@ module.exports = (config, provider, servicePath) => {
     );
   }
 
+  const mappingTemplatesLocation = config.mappingTemplatesLocation || 'mapping-templates'
   const mappingTemplates = config.mappingTemplates || []
 
   const schemaPath = path.join(servicePath, config.schema || 'schema.graphql');
@@ -42,6 +43,7 @@ module.exports = (config, provider, servicePath) => {
     serviceRoleArn: config.serviceRole,
     // TODO verify dataSources structure
     dataSources,
+    mappingTemplatesLocation,
     mappingTemplates
   };
 };

--- a/serverless-appsync-plugin/index.js
+++ b/serverless-appsync-plugin/index.js
@@ -155,12 +155,12 @@ class ServerlessAppsyncPlugin {
         dataSourceName: tpl.dataSource,
         fieldName: tpl.field,
         requestMappingTemplate: fs.readFileSync(
-          `mapping-templates/${tpl.request}`,
+          `${resolvedConfig.mappingTemplatesLocation}/${tpl.request}`,
           'utf8',
         ),
         typeName: tpl.type,
         responseMappingTemplate: fs.readFileSync(
-          `mapping-templates/${tpl.response}`,
+          `${resolvedConfig.mappingTemplatesLocation}/${tpl.response}`,
           'utf8',
         ),
       };

--- a/serverless-appsync-plugin/index.js
+++ b/serverless-appsync-plugin/index.js
@@ -144,138 +144,27 @@ class ServerlessAppsyncPlugin {
 
   createResolvers() {
     this.serverless.cli.log('Creating resolvers...');
+    const resolvedConfig = this.serverless.service.custom.appSync.resolvedConfig;
     const awsResult = this.serverless.service.custom.appSync.awsResult;
-
-    // TODO: make this configurable?!
+    // TODO: make this more configurable?!
     // TODO: make calls async
-    const resolverParams = [
-      {
+    // eslint-disable-next-line arrow-body-style
+    const resolverParams = resolvedConfig.mappingTemplates.map((tpl) => {
+      return {
         apiId: awsResult.graphqlApi.apiId,
-        dataSourceName: 'Users',
-        fieldName: 'getUserInfo',
+        dataSourceName: tpl.dataSource,
+        fieldName: tpl.field,
         requestMappingTemplate: fs.readFileSync(
-          'mapping-templates/getUserInfo-request-mapping-template.txt',
+          `mapping-templates/${tpl.request}`,
           'utf8',
         ),
-        typeName: 'Query',
+        typeName: tpl.type,
         responseMappingTemplate: fs.readFileSync(
-          'mapping-templates/getUserInfo-response-mapping-template.txt',
+          `mapping-templates/${tpl.response}`,
           'utf8',
         ),
-      },
-      {
-        apiId: awsResult.graphqlApi.apiId,
-        dataSourceName: 'Users',
-        fieldName: 'meInfo',
-        requestMappingTemplate: fs.readFileSync(
-          'mapping-templates/meInfo-request-mapping-template.txt',
-          'utf8',
-        ),
-        typeName: 'Query',
-        responseMappingTemplate: fs.readFileSync(
-          'mapping-templates/meInfo-response-mapping-template.txt',
-          'utf8',
-        ),
-      },
-      {
-        apiId: awsResult.graphqlApi.apiId,
-        dataSourceName: 'Tweets',
-        fieldName: 'topTweet',
-        requestMappingTemplate: fs.readFileSync(
-          'mapping-templates/topTweet-request-mapping-template.txt',
-          'utf8',
-        ),
-        typeName: 'User',
-        responseMappingTemplate: fs.readFileSync(
-          'mapping-templates/topTweet-response-mapping-template.txt',
-          'utf8',
-        ),
-      },
-      {
-        apiId: awsResult.graphqlApi.apiId,
-        dataSourceName: 'Tweets',
-        fieldName: 'tweets',
-        requestMappingTemplate: fs.readFileSync(
-          'mapping-templates/tweets-request-mapping-template.txt',
-          'utf8',
-        ),
-        typeName: 'User',
-        responseMappingTemplate: fs.readFileSync(
-          'mapping-templates/tweets-response-mapping-template.txt',
-          'utf8',
-        ),
-      },
-      {
-        apiId: awsResult.graphqlApi.apiId,
-        dataSourceName: 'Tweets',
-        fieldName: 'createTweet',
-        requestMappingTemplate: fs.readFileSync(
-          'mapping-templates/createTweet-request-mapping-template.txt',
-          'utf8',
-        ),
-        typeName: 'Mutation',
-        responseMappingTemplate: fs.readFileSync(
-          'mapping-templates/createTweet-response-mapping-template.txt',
-          'utf8',
-        ),
-      },
-      {
-        apiId: awsResult.graphqlApi.apiId,
-        dataSourceName: 'Tweets',
-        fieldName: 'deleteTweet',
-        requestMappingTemplate: fs.readFileSync(
-          'mapping-templates/deleteTweet-request-mapping-template.txt',
-          'utf8',
-        ),
-        typeName: 'Mutation',
-        responseMappingTemplate: fs.readFileSync(
-          'mapping-templates/deleteTweet-response-mapping-template.txt',
-          'utf8',
-        ),
-      },
-      {
-        apiId: awsResult.graphqlApi.apiId,
-        dataSourceName: 'Tweets',
-        fieldName: 'reTweet',
-        requestMappingTemplate: fs.readFileSync(
-          'mapping-templates/reTweet-request-mapping-template.txt',
-          'utf8',
-        ),
-        typeName: 'Mutation',
-        responseMappingTemplate: fs.readFileSync(
-          'mapping-templates/reTweet-response-mapping-template.txt',
-          'utf8',
-        ),
-      },
-      {
-        apiId: awsResult.graphqlApi.apiId,
-        dataSourceName: 'Tweets',
-        fieldName: 'updateTweet',
-        requestMappingTemplate: fs.readFileSync(
-          'mapping-templates/updateTweet-request-mapping-template.txt',
-          'utf8',
-        ),
-        typeName: 'Mutation',
-        responseMappingTemplate: fs.readFileSync(
-          'mapping-templates/updateTweet-response-mapping-template.txt',
-          'utf8',
-        ),
-      },
-      {
-        apiId: awsResult.graphqlApi.apiId,
-        dataSourceName: 'Users',
-        fieldName: 'updateUserInfo',
-        requestMappingTemplate: fs.readFileSync(
-          'mapping-templates/updateUserInfo-request-mapping-template.txt',
-          'utf8',
-        ),
-        typeName: 'Mutation',
-        responseMappingTemplate: fs.readFileSync(
-          'mapping-templates/updateUserInfo-response-mapping-template.txt',
-          'utf8',
-        ),
-      },
-    ];
+      };
+    });
 
     return BbPromise.map(resolverParams, params =>
       this.provider.request('AppSync', 'createResolver', params));


### PR DESCRIPTION
As a first stab at #25 this uses the `custom.appSync.mappingTemplates` key to explicitly set mappingTemplate details as described in #25, and adds a new key `custom.appSync.mappingTemplatesLocation` for template files location (and still defaults to `mapping-templates`).