### PR TITLE
Added update-appsync/delete-appsync commands + readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,61 @@
-# serverless-appsync-plugin
+<h1 align="center">
+  Serverless-AppSync-Plugin 👌
+  <h4 align="center"><a href="https://serverless.com" target="_blank">Serverless</a> plugin that allows you to deploy, update or delete your <a href="https://aws.amazon.com/appsync" target="_blank">AWS AppSync</a> API's with ease.</h4>
+  <br>
+</h1>
+
+Tired of 🚀 **deploying**, ✏️ **updating**, and ❌ **deleting** your AppSync API's using the AWS AppSync dashboard? You can now develop all of your AppSync API's locally using **Serverless** + **Serverless-AppSync-Plugin**! With support for <a href="https://aws.amazon.com/dynamodb" target="_blank">AWS DynamoDB</a>, <a href="https://aws.amazon.com/lambda" target="_blank">AWS Lambda</a>, and <a href="https://aws.amazon.com/elasticsearch-service" target="_blank">AWS Elastic Search</a>; you have everything you need to get started developing your AppSync API's locally!
 
 ![appsync architecture](https://user-images.githubusercontent.com/1587005/36063617-fe8d4e5e-0e33-11e8-855b-447513ba7084.png)
 
-# Steps to use this plugin:
+<details>
+ <summary><strong>Table of Contents</strong> (click to expand)</summary>
 
-*Step 1*
+* [Getting Started](#-getting-started)
+* [Installation](#-installation)
+* [Usage](#️-usage)
+* [Contributing](#-contributing)
+* [Credits](#️-credits)
+</details>
 
-In your root directory, install this plugin:
+## ⚡️ Getting Started
 
-```yml
+Be sure to check out all that <a href="https://aws.amazon.com/appsync" target="_blank">AWS AppSync</a> has to offer. Here are a few resources to help you understand everything needed to get started!
+
+* <a target="_blank" href="https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference.html">Mapping Templates</a> - Not sure how to create Mapping Templates for **DynamoDB**, **Lambda** or **Elastic Search**? Here's a great place to start!
+* <a target="_blank" href="https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference.html">Data Sources and Resolvers</a> - Get more information on what data sources are supported and how to set them up!
+* <a target="_blank" href="https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference.html">Security</a> - Checkout this guide to find out more information on securing your API endpoints with AWS_IAM or Cognito User Pools!
+
+## 💾 Installation
+
+Install the plugin via <a href="https://yarnpkg.com/lang/en/docs/install/">Yarn</a> (recommended)
+
+```
 yarn add serverless-appsync-plugin
 ```
 
-*Step 2*
+or via <a href="https://docs.npmjs.com/cli/install">NPM</a>
 
-Create schema.graphql
+```
+npm install serverless-appsync-plugin
+```
+### Configuring the plugin
 
-*Step 3*
+Add ```serverless-appsync-plugin``` to the plugins section of ```serverless.yml```
 
-Add custom config to serverless.yml:
-
-```yaml
+```
 plugins:
    - serverless-appsync-plugin
+```  
 
+Add the following example config to the custom section of ```serverless.yml```
+
+```yaml
 custom:
-  accountId: abc
+  accountId: abc # found here https://console.aws.amazon.com/billing/home?#/account
   appSync:
     name:  # defaults to api
+    # apiId # only required for update-appsync/delete-appsync
     authenticationType: AMAZON_COGNITO_USER_POOLS
     userPoolConfig:
       awsRegion: # required # region
@@ -64,14 +92,43 @@ custom:
           serviceRoleArn: "arn:aws:iam::${self:custom.accountId}:role/Lambda-${self:custom.appSync.serviceRole}"
 ```
 
-**NOTE** Please create data sources and other resources in serverless.yml file
-**NOTE** if you are planning on using elastic search, for the time being you'll need to create a domain separately to obtain an ElasticSearch endpoint config once it is ready ***before the next step***
+> Be sure to replace all variables that have been commented out, or have an empty value.
+
+## ▶️ Usage
+
+### `serverless deploy-appsync`
+
+This command will **deploy** a new AppSync API endpoint using the ```name``` specified in the custom section of ```serverless.yml``` under ```appSync```.
+
+### `serverless update-appsync`
+
+This command will **update** an existing AppSync API endpoint using the ```apiId``` specified in the custom section of ```serverless.yml``` under ```appSync```. (Data sources/resolvers will be **automatically** created if they don't already exist)
+
+### `serverless delete-appsync`
+
+This command will **delete** an existing AppSync API endpoint using the ```apiId``` specified in the custom section of ```serverless.yml``` under ```appSync```.
+
+---
+
+> If the ```apiId``` you are trying to update or delete does not exist, an error will be thrown. Login to your AWS AppSync dashboard; retrieve the API ID that you are trying to update or delete, and set it as the ```apiId``` in ```serverless.yml```
+
+```
+custom:
+  appSync:
+    apiId: xxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+## 📝 Notes
+
+* If you are planning on using <a target="_blank" href="https://aws.amazon.com/elasticsearch-service">AWS Elastic Search</a>, you will need to create an Elastic Search domain/endpoint on AWS and set it as the ```endpoint``` option in  ```serverless.yml``` **before** deploying.
+
+## 🎁 Contributing
+
+If you have any questions, please feel free to reach out to me directly on Twitter <a target="_blank" href="https://twitter.com/sidg_sid">Sid Gupta</a>.
 
 
-# Contributions:
+## ❤️ Credits
 
-If you have any questions, please feel free to reach out to me directly on twitter [Sid Gupta](https://twitter.com/sidg_sid).
-
-Big Thanks! [Nik Graf](https://twitter.com/nikgraf), [Philipp Müns](https://twitter.com/pmmuens) and [Jon Patel](https://twitter.com/superpatell) for helping to build this plugin.
+Big Thanks to <a target="_blank" href="https://twitter.com/nikgraf">Nik Graf</a>, <a target="_blank" href="https://twitter.com/pmmuens">Philipp Müns</a> and <a target="_blank" href="https://twitter.com/superpatell">Jon Patel</a> for helping to build this plugin!
 
 We are always looking for open source contributions. So, feel free to create issues/contribute to this repo.

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -18,6 +18,7 @@ custom:
   accountId: abc
   appSync:
     # name:  # defaults to api
+    # apiId # only required for update-appsync
     authenticationType: AMAZON_COGNITO_USER_POOLS
     userPoolConfig:
       awsRegion: # required # region

--- a/get-config.js
+++ b/get-config.js
@@ -36,6 +36,7 @@ module.exports = (config, provider, servicePath) => {
 
   return {
     name: config.name || 'api',
+    apiId: config.apiId,
     region: provider.region,
     authenticationType: config.authenticationType,
     schema: schemaContent,

--- a/index.js
+++ b/index.js
@@ -1,28 +1,50 @@
-const fs = require('fs');
-const BbPromise = require('bluebird');
-const async = require('async');
-const getConfig = require('./get-config');
+const fs = require("fs");
+const BbPromise = require("bluebird");
+const async = require("async");
+const getConfig = require("./get-config");
 
 class ServerlessAppsyncPlugin {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
-    this.provider = this.serverless.getProvider('aws');
+    this.provider = this.serverless.getProvider("aws");
     this.commands = {
-      'deploy-appsync': {
-        lifecycleEvents: ['deploy'],
+      "delete-appsync": {
+        lifecycleEvents: ["delete"]
       },
+      "deploy-appsync": {
+        lifecycleEvents: ["deploy"]
+      },
+      "update-appsync": {
+        lifecycleEvents: ["update"]
+      }
     };
     this.hooks = {
-      'deploy-appsync:deploy': () => BbPromise.bind(this)
-        .then(this.loadConfig)
-        .then(this.createGraphQLEndpoint)
-        .then(this.attachDataSources)
-        .then(this.createGraphQLSchema)
-        .then(this.monitorGraphQLSchemaCreation)
-        .then(this.getSchemaForGraphQLEndpoint)
-        .then(this.createResolvers)
-        .then(this.listTypes),
+      "delete-appsync:delete": () =>
+        BbPromise.bind(this)
+          .then(this.loadConfig)
+          .then(this.deleteGraphQLEndpoint),
+      "deploy-appsync:deploy": () =>
+        BbPromise.bind(this)
+          .then(this.loadConfig)
+          .then(this.createGraphQLEndpoint)
+          .then(this.attachDataSources)
+          .then(this.createGraphQLSchema)
+          .then(this.monitorGraphQLSchemaCreation)
+          .then(this.getSchemaForGraphQLEndpoint)
+          .then(this.createResolvers)
+          .then(this.listTypes),
+      "update-appsync:update": () =>
+        BbPromise.bind(this)
+          .then(this.loadConfig)
+          .then(this.updateGraphQLEndpoint)
+          .then(this.getInitialTypes)
+          .then(this.updateDataSources)
+          .then(this.createGraphQLSchema)
+          .then(this.monitorGraphQLSchemaCreation)
+          .then(this.getSchemaForGraphQLEndpoint)
+          .then(this.updateResolvers)
+          .then(this.listTypes)
     };
   }
 
@@ -36,87 +58,228 @@ class ServerlessAppsyncPlugin {
     this.serverless.service.custom.appSync.resolvedConfig = config;
   }
 
+  deleteGraphQLEndpoint() {
+    this.serverless.cli.log("Deleting GraphQL Endpoint...");
+    const resolvedConfig = this.serverless.service.custom.appSync
+      .resolvedConfig;
+
+    const { apiId } = resolvedConfig;
+    return this.provider
+      .request("AppSync", "deleteGraphqlApi", {
+        apiId
+      })
+      .then(data => {
+        if (data) {
+          this.serverless.cli.log(
+            `Successfully deleted GraphQL Endpoint: ${apiId}`
+          );
+        }
+      });
+  }
+
   createGraphQLEndpoint() {
-    this.serverless.cli.log('Creating GraphQL Endpoint...');
-    const resolvedConfig = this.serverless.service.custom.appSync.resolvedConfig;
-    return this.provider.request('AppSync', 'createGraphqlApi', {
-      authenticationType: resolvedConfig.authenticationType,
-      name: resolvedConfig.name,
-      userPoolConfig: {
-        awsRegion: resolvedConfig.region,
-        defaultAction: resolvedConfig.userPoolConfig.defaultAction,
-        userPoolId: resolvedConfig.userPoolConfig.userPoolId,
-      },
-    }).then((data) => {
-      this.serverless.cli.log(`GraphQL API ID: ${data.graphqlApi.apiId}`);
-      this.serverless.cli.log(`GraphQL Endpoint: ${data.graphqlApi.uris.GRAPHQL}`);
-      // NOTE: storign the config in the appSync object
-      this.serverless.service.custom.appSync.awsResult = data;
-    });
+    this.serverless.cli.log("Creating GraphQL Endpoint...");
+    const resolvedConfig = this.serverless.service.custom.appSync
+      .resolvedConfig;
+
+    return this.provider
+      .request("AppSync", "createGraphqlApi", {
+        authenticationType: resolvedConfig.authenticationType,
+        name: resolvedConfig.name,
+        userPoolConfig: {
+          awsRegion: resolvedConfig.region,
+          defaultAction: resolvedConfig.userPoolConfig.defaultAction,
+          userPoolId: resolvedConfig.userPoolConfig.userPoolId
+        }
+      })
+      .then(data => {
+        this.serverless.cli.log(`GraphQL API ID: ${data.graphqlApi.apiId}`);
+        this.serverless.cli.log(
+          `GraphQL Endpoint: ${data.graphqlApi.uris.GRAPHQL}`
+        );
+        // NOTE: storing the config in the appSync object
+        this.serverless.service.custom.appSync.awsResult = data;
+      });
+  }
+
+  updateGraphQLEndpoint() {
+    this.serverless.cli.log("Updating GraphQL Endpoint...");
+    const resolvedConfig = this.serverless.service.custom.appSync
+      .resolvedConfig;
+
+    return this.provider
+      .request("AppSync", "updateGraphqlApi", {
+        apiId: resolvedConfig.apiId,
+        authenticationType: resolvedConfig.authenticationType,
+        name: resolvedConfig.name,
+        userPoolConfig: {
+          awsRegion: resolvedConfig.region,
+          defaultAction: resolvedConfig.userPoolConfig.defaultAction,
+          userPoolId: resolvedConfig.userPoolConfig.userPoolId
+        }
+      })
+      .then(data => {
+        this.serverless.cli.log(`GraphQL API ID: ${data.graphqlApi.apiId}`);
+        this.serverless.cli.log(
+          `GraphQL Endpoint: ${data.graphqlApi.uris.GRAPHQL}`
+        );
+        // NOTE: storing the config in the appSync object
+        this.serverless.service.custom.appSync.awsResult = data;
+      });
   }
 
   attachDataSources() {
-    this.serverless.cli.log('Attaching data sources...');
-    const resolvedConfig = this.serverless.service.custom.appSync.resolvedConfig;
+    this.serverless.cli.log("Attaching data sources...");
+    const resolvedConfig = this.serverless.service.custom.appSync
+      .resolvedConfig;
     const awsResult = this.serverless.service.custom.appSync.awsResult;
 
-    // TODO: make this more configurable?!
     // eslint-disable-next-line arrow-body-style
-    const datasourceParams = resolvedConfig.dataSources.map((ds) => {
+    const datasourceParams = resolvedConfig.dataSources.map(ds => {
       let config;
       switch (ds.type) {
-        case 'AWS_LAMBDA':
+        case "AWS_LAMBDA":
           config = {
             lambdaConfig: {
-              lambdaFunctionArn: ds.config.lambdaFunctionArn,
-            },
+              lambdaFunctionArn: ds.config.lambdaFunctionArn
+            }
           };
           break;
-        case 'AMAZON_DYNAMODB':
+        case "AMAZON_DYNAMODB":
           config = {
             dynamodbConfig: {
               awsRegion: resolvedConfig.region,
-              tableName: ds.config.tableName,
-            },
+              tableName: ds.config.tableName
+            }
           };
           if (ds.config.useCallerCredentials) {
-            Object.assign(config, { useCallerCredentials: ds.config.useCallerCredentials });
+            Object.assign(config, {
+              useCallerCredentials: ds.config.useCallerCredentials
+            });
           }
           break;
-        case 'AMAZON_ELASTICSEARCH':
+        case "AMAZON_ELASTICSEARCH":
           config = {
             elasticsearchConfig: {
               awsRegion: resolvedConfig.region,
-              endpoint: ds.config.endpoint,
-            },
+              endpoint: ds.config.endpoint
+            }
           };
           break;
         default:
-          this.serverless.cli.log('Data Source Type not supported', ds.type);
+          this.serverless.cli.log("Data Source Type not supported", ds.type);
       }
       const dataSource = {
         apiId: awsResult.graphqlApi.apiId,
         name: ds.name,
         type: ds.type,
         description: ds.description,
-        serviceRoleArn: ds.config.serviceRoleArn,
+        serviceRoleArn: ds.config.serviceRoleArn
       };
       Object.assign(dataSource, config);
       return dataSource;
     });
 
     return BbPromise.map(datasourceParams, params =>
-      this.provider.request('AppSync', 'createDataSource', params));
+      this.provider.request("AppSync", "createDataSource", params).then(() => {
+        this.serverless.cli.log(`Created new data source: ${params.name}`);
+      })
+    );
+  }
+
+  updateDataSources() {
+    this.serverless.cli.log("Updating data sources...");
+    const resolvedConfig = this.serverless.service.custom.appSync
+      .resolvedConfig;
+    const awsResult = this.serverless.service.custom.appSync.awsResult;
+
+    // eslint-disable-next-line arrow-body-style
+    const datasourceParams = resolvedConfig.dataSources.map(ds => {
+      let config;
+      switch (ds.type) {
+        case "AWS_LAMBDA":
+          config = {
+            lambdaConfig: {
+              lambdaFunctionArn: ds.config.lambdaFunctionArn
+            }
+          };
+          break;
+        case "AMAZON_DYNAMODB":
+          config = {
+            dynamodbConfig: {
+              awsRegion: resolvedConfig.region,
+              tableName: ds.config.tableName
+            }
+          };
+          if (ds.config.useCallerCredentials) {
+            Object.assign(config, {
+              useCallerCredentials: ds.config.useCallerCredentials
+            });
+          }
+          break;
+        case "AMAZON_ELASTICSEARCH":
+          config = {
+            elasticsearchConfig: {
+              awsRegion: resolvedConfig.region,
+              endpoint: ds.config.endpoint
+            }
+          };
+          break;
+        default:
+          this.serverless.cli.log("Data Source Type not supported", ds.type);
+      }
+      const dataSource = {
+        apiId: awsResult.graphqlApi.apiId,
+        name: ds.name,
+        type: ds.type,
+        description: ds.description,
+        serviceRoleArn: ds.config.serviceRoleArn
+      };
+      Object.assign(dataSource, config);
+
+      return dataSource;
+    });
+
+    return BbPromise.map(datasourceParams, resolver => {
+      return this.provider
+        .request("AppSync", "updateDataSource", resolver)
+        .then(() => {
+          this.serverless.cli.log(`Updated data source: ${resolver.name}`);
+        })
+        .catch(error => {
+          switch (error.statusCode) {
+            case 404:
+              return new BbPromise((resolve, reject) => {
+                this.provider
+                  .request("AppSync", "createDataSource", resolver)
+                  .then(() => {
+                    this.serverless.cli.log(
+                      `Created new data source: ${resolver.name}`
+                    );
+                    resolve();
+                  })
+                  .catch(error => {
+                    reject(error);
+                  });
+              });
+              break;
+            default:
+              this.serverless.cli.log(e);
+          }
+        });
+    });
   }
 
   createGraphQLSchema() {
-    this.serverless.cli.log('Creating GraphQL Schema');
-    const resolvedConfig = this.serverless.service.custom.appSync.resolvedConfig;
+    this.serverless.cli.log("Creating GraphQL Schema");
+    const resolvedConfig = this.serverless.service.custom.appSync
+      .resolvedConfig;
+
     const awsResult = this.serverless.service.custom.appSync.awsResult;
     const schema = Buffer.from(resolvedConfig.schema);
-    return this.provider.request('AppSync', 'startSchemaCreation', {
+    return this.provider.request("AppSync", "startSchemaCreation", {
       apiId: awsResult.graphqlApi.apiId,
-      definition: schema,
+      definition: schema
     });
   }
 
@@ -128,76 +291,151 @@ class ServerlessAppsyncPlugin {
       async.until(
         () => isReady,
         // eslint-disable-next-line arrow-body-style
-        (callback) => {
-          return this.provider.request('AppSync', 'getSchemaCreationStatus', {
-            apiId: awsResult.graphqlApi.apiId,
-          }).then((result) => {
-            this.serverless.cli.log(result.status);
-            if (result.status === 'SUCCESS') {
-              this.serverless.cli.log('schema for GraphQL endpoint created...');
-              isReady = true;
-            }
-            if (result.status === 'FAILED') {
-              this.serverless.cli.log('Creating schema for GraphQL endpoint failed...');
-              reject(result.details);
-            }
-            callback();
-          }).catch((error) => {
-            reject(error);
-          });
+        callback => {
+          return this.provider
+            .request("AppSync", "getSchemaCreationStatus", {
+              apiId: awsResult.graphqlApi.apiId
+            })
+            .then(result => {
+              this.serverless.cli.log(`${result.status} | ${result.details}`);
+              if (result.status === "SUCCESS") {
+                this.serverless.cli.log(
+                  "Schema for GraphQL endpoint created..."
+                );
+                isReady = true;
+              }
+              if (result.status === "FAILED") {
+                this.serverless.cli.log(
+                  "Creating schema for GraphQL endpoint failed..."
+                );
+                reject(result.details);
+              }
+              callback();
+            })
+            .catch(error => {
+              reject(error);
+            });
         },
-        () => resolve(),
+        () => resolve()
       );
     });
   }
 
   getSchemaForGraphQLEndpoint() {
-    this.serverless.cli.log('Getting schema for GraphQL endpoint...');
+    this.serverless.cli.log("Getting schema for GraphQL endpoint...");
     const awsResult = this.serverless.service.custom.appSync.awsResult;
 
-    return this.provider.request('AppSync', 'getIntrospectionSchema', {
+    return this.provider.request("AppSync", "getIntrospectionSchema", {
       apiId: awsResult.graphqlApi.apiId,
-      format: 'SDL',
+      format: "SDL"
     });
   }
 
   createResolvers() {
-    this.serverless.cli.log('Creating resolvers...');
-    const resolvedConfig = this.serverless.service.custom.appSync.resolvedConfig;
+    this.serverless.cli.log("Creating resolvers...");
+    const resolvedConfig = this.serverless.service.custom.appSync
+      .resolvedConfig;
     const awsResult = this.serverless.service.custom.appSync.awsResult;
-    // TODO: make this more configurable?!
-    // TODO: make calls async
+
     // eslint-disable-next-line arrow-body-style
-    const resolverParams = resolvedConfig.mappingTemplates.map((tpl) => {
+    const resolverParams = resolvedConfig.mappingTemplates.map(tpl => {
       return {
         apiId: awsResult.graphqlApi.apiId,
         dataSourceName: tpl.dataSource,
         fieldName: tpl.field,
         requestMappingTemplate: fs.readFileSync(
           `${resolvedConfig.mappingTemplatesLocation}/${tpl.request}`,
-          'utf8',
+          "utf8"
         ),
         typeName: tpl.type,
         responseMappingTemplate: fs.readFileSync(
           `${resolvedConfig.mappingTemplatesLocation}/${tpl.response}`,
-          'utf8',
-        ),
+          "utf8"
+        )
       };
     });
 
     return BbPromise.map(resolverParams, params =>
-      this.provider.request('AppSync', 'createResolver', params));
+      this.provider.request("AppSync", "createResolver", params).then(() => {
+        this.serverless.cli.log(
+          `Created new resolver on field: ${params.fieldName}`
+        );
+      })
+    );
+  }
+
+  updateResolvers() {
+    this.serverless.cli.log("Updating resolvers...");
+    const resolvedConfig = this.serverless.service.custom.appSync
+      .resolvedConfig;
+    const awsResult = this.serverless.service.custom.appSync.awsResult;
+
+    // eslint-disable-next-line arrow-body-style
+    const resolverParams = resolvedConfig.mappingTemplates.map(tpl => {
+      return {
+        apiId: awsResult.graphqlApi.apiId,
+        dataSourceName: tpl.dataSource,
+        fieldName: tpl.field,
+        requestMappingTemplate: fs.readFileSync(
+          `${resolvedConfig.mappingTemplatesLocation}/${tpl.request}`,
+          "utf8"
+        ),
+        typeName: tpl.type,
+        responseMappingTemplate: fs.readFileSync(
+          `${resolvedConfig.mappingTemplatesLocation}/${tpl.response}`,
+          "utf8"
+        )
+      };
+    });
+
+    return BbPromise.map(resolverParams, params => {
+      return this.provider
+        .request("AppSync", "updateResolver", params)
+        .then(() => {
+          this.serverless.cli.log(
+            `Updated resolver on field: ${params.fieldName}`
+          );
+        })
+        .catch(error => {
+          switch (error.statusCode) {
+            case 404:
+              return new BbPromise((resolve, reject) => {
+                this.provider
+                  .request("AppSync", "createResolver", params)
+                  .then(() => {
+                    this.serverless.cli.log(
+                      `Created new resolver on field: ${params.fieldName}`
+                    );
+                    resolve();
+                  })
+                  .catch(error => {
+                    reject(error);
+                  });
+              });
+              break;
+            default:
+              this.serverless.cli.log(e);
+          }
+        });
+    });
   }
 
   listTypes() {
     const awsResult = this.serverless.service.custom.appSync.awsResult;
 
-    return this.provider.request('AppSync', 'listTypes', {
-      apiId: awsResult.graphqlApi.apiId,
-      format: 'SDL',
-    }).then((result) => {
-      this.serverless.cli.log(result);
-    });
+    return this.provider
+      .request("AppSync", "listTypes", {
+        apiId: awsResult.graphqlApi.apiId,
+        format: "SDL"
+      })
+      .then(result => {
+        this.serverless.cli.log(
+          `Type List: ${result.types.map(type => type.name)}`
+        );
+        this.serverless.cli.log(
+          "All done deploying/updating data sources and resolvers."
+        );
+      });
   }
 }
 


### PR DESCRIPTION
Added **2** new commands for the serverless-appsync plugin. 

1.  **update-appsync** 

- Requires you to set an `apiId` in serverless.yml on the appsync config. (Example in the `example/serverless.yml` file) 
- `apiId` should be updated/specified manually every time you deploy a new AppSync API (Maybe this can be automatically updated by the deployment script in the future?)
- Script will automatically create missing data sources and resolvers, if you add more to your serverless.yml file. (Shouldn't have to create a whole new API just to add new data sources/resolvers :P)

2.  **delete-appsync**

- Will delete the AppSync api specified by the `apiId` config in your serverless.yml file.

**Note**:  

- Added a little bit more detailed/visually appealing logging to each of the functions and fixed the output for the listTypes function. (Was just outputting [object][object] previously)
- We should get a nice animated console gif showing the commands being run and the output for the header image on the ReadMe :D