### PR TITLE
Added support for NONE type data sources'

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,6 +166,9 @@ class ServerlessAppsyncPlugin {
             }
           };
           break;
+        case "NONE":
+          config = {};
+          break;
         default:
           this.serverless.cli.log("Data Source Type not supported", ds.type);
       }
@@ -224,6 +227,9 @@ class ServerlessAppsyncPlugin {
               endpoint: ds.config.endpoint
             }
           };
+          break;
+        case "NONE":
+          config = {};
           break;
         default:
           this.serverless.cli.log("Data Source Type not supported", ds.type);


### PR DESCRIPTION
A week ago AWS added the supports for a new data source type: `NONE`:

- [Blog: new AWS AppSync features and whitelist removal ](https://aws.amazon.com/blogs/mobile/new-aws-appsync-features-and-whitelist-removal/)
- [API Reference: supported types](https://docs.aws.amazon.com/appsync/latest/APIReference/API_UpdateDataSource.html#API_UpdateDataSource_RequestSyntax)