### PR TITLE
Return Callback To Prevent Warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -377,7 +377,8 @@ class ServerlessAppsyncPlugin {
                 this.serverless.cli.log('Creating schema for GraphQL endpoint failed...');
                 reject(result.details);
               }
-              callback();
+              // returning to avoid warnings
+              return callback();
             })
             .catch((error) => {
               reject(error);


### PR DESCRIPTION
```Bash
(node:38968) Warning: a promise was created in a handler at /Users/me/Desktop/repo/app/node_modules/serverless-appsync-plugin/index.js:403:15 but was not returned from it, see http://goo.gl/rRqMUw at new Promise (/Users/me/Desktop/repo/app/node_modules/bluebird/js/release/promise.js:79:10)
````
Technically nothing is wrong. Need to return the callback to avoid this warning.