### PR TITLE
Support Cognito pools and data sources in a different region to AppSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ custom:
         description: # DynamoDB Table Description
         config:
           tableName: # DynamoDB Table Name
+          awsRegion: # required # region
           serviceRoleArn: "arn:aws:iam::${self:custom.accountId}:role/dynamo-${self:custom.appSync.serviceRole}"
       - type: AMAZON_ELASTICSEARCH
         name: # data source name
@@ -93,10 +94,12 @@ custom:
         config:
           endpoint: # required # "https://{DOMAIN}.{REGION}.es.amazonaws.com"
           serviceRoleArn: "arn:aws:iam::${self:custom.accountId}:role/elasticSearch-${self:custom.appSync.serviceRole}"
+          awsRegion: # required # region
       - type: AWS_LAMBDA
         name: # data source name
         description: 'Lambda DataSource'
         config:
+          
           lambdaFunctionArn: "arn:aws:lambda:us-east-1:${self:custom.accountId}:function:appsync-example-dev-graphql"
           serviceRoleArn: "arn:aws:iam::${self:custom.accountId}:role/Lambda-${self:custom.appSync.serviceRole}"
 ```

--- a/index.js
+++ b/index.js
@@ -190,7 +190,7 @@ class ServerlessAppsyncPlugin {
         case 'AMAZON_DYNAMODB':
           config = {
             dynamodbConfig: {
-              awsRegion: resolvedConfig.region,
+              awsRegion: ds.config.awsRegion,
               tableName: ds.config.tableName,
             },
           };
@@ -203,7 +203,7 @@ class ServerlessAppsyncPlugin {
         case 'AMAZON_ELASTICSEARCH':
           config = {
             elasticsearchConfig: {
-              awsRegion: resolvedConfig.region,
+              awsRegion: ds.config.awsRegion,
               endpoint: ds.config.endpoint,
             },
           };

--- a/index.js
+++ b/index.js
@@ -216,7 +216,6 @@ class ServerlessAppsyncPlugin {
       }
       const dataSource = {
         apiId: awsResult.graphqlApi.apiId,
-        awsRegion: ds.config.awsRegion,
         name: ds.name,
         type: ds.type,
         description: ds.description,
@@ -280,7 +279,6 @@ class ServerlessAppsyncPlugin {
         apiId: awsResult.graphqlApi.apiId,
         name: ds.name,
         type: ds.type,
-        awsRegion: ds.config.awsRegion,
         description: ds.description,
         serviceRoleArn: ds.config.serviceRoleArn,
       };

--- a/index.js
+++ b/index.js
@@ -216,6 +216,7 @@ class ServerlessAppsyncPlugin {
       }
       const dataSource = {
         apiId: awsResult.graphqlApi.apiId,
+        awsRegion: ds.config.awsRegion,
         name: ds.name,
         type: ds.type,
         description: ds.description,
@@ -251,7 +252,7 @@ class ServerlessAppsyncPlugin {
         case 'AMAZON_DYNAMODB':
           config = {
             dynamodbConfig: {
-              awsRegion: resolvedConfig.region,
+              awsRegion: ds.config.awsRegion,
               tableName: ds.config.tableName,
             },
           };
@@ -264,7 +265,7 @@ class ServerlessAppsyncPlugin {
         case 'AMAZON_ELASTICSEARCH':
           config = {
             elasticsearchConfig: {
-              awsRegion: resolvedConfig.region,
+              awsRegion: ds.config.awsRegion,
               endpoint: ds.config.endpoint,
             },
           };
@@ -279,6 +280,7 @@ class ServerlessAppsyncPlugin {
         apiId: awsResult.graphqlApi.apiId,
         name: ds.name,
         type: ds.type,
+        awsRegion: ds.config.awsRegion,
         description: ds.description,
         serviceRoleArn: ds.config.serviceRoleArn,
       };

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ class ServerlessAppsyncPlugin {
 
     if (resolvedConfig.authenticationType === 'AMAZON_COGNITO_USER_POOLS') {
       config.userPoolConfig = {
-        awsRegion: resolvedConfig.region,
+        awsRegion: resolvedConfig.userPoolConfig.awsRegion,
         defaultAction: resolvedConfig.userPoolConfig.defaultAction,
         userPoolId: resolvedConfig.userPoolConfig.userPoolId,
       };
@@ -150,7 +150,7 @@ class ServerlessAppsyncPlugin {
 
     if (resolvedConfig.authenticationType === 'AMAZON_COGNITO_USER_POOLS') {
       config.userPoolConfig = {
-        awsRegion: resolvedConfig.region,
+        awsRegion: resolvedConfig.userPoolConfig.awsRegion,
         defaultAction: resolvedConfig.userPoolConfig.defaultAction,
         userPoolId: resolvedConfig.userPoolConfig.userPoolId,
       };


### PR DESCRIPTION
I need to deploy to eu-west-1 for AppSync, but by resources are in a different region (eu-west-2).

Whilst the documentation suggests you can (and should) provide a region for these items, the default top level region is used instead.

This PR requires a region be specified for each data source or Cognito pool which is then used when configuring AppSync.


