### PR TITLE
Add AWS_IAM authentication type to readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ custom:
   appSync:
     name:  # defaults to api
     # apiKey # only required for update-appsync/delete-appsync
-    authenticationType: API_KEY or AMAZON_COGNITO_USER_POOLS or OPENID_CONNECT
+    authenticationType: API_KEY or AWS_IAM or AMAZON_COGNITO_USER_POOLS or OPENID_CONNECT
     # if AMAZON_COGNITO_USER_POOLS
     userPoolConfig:
       awsRegion: # required # region


### PR DESCRIPTION
Make it clear that AWS_IAM as defined [here](https://github.com/sid88in/serverless-appsync-plugin/blob/4273e9d142d426d4be89eecedde6f491dfca0710/get-config.js#L18) is supported as an authentication type.