### PR TITLE
Fix broken schema.graphql path from previous merged PR

### DIFF
--- a/get-config.js
+++ b/get-config.js
@@ -41,7 +41,6 @@ module.exports = (config, provider, servicePath) => {
 
   const schemaPath = path.join(
     servicePath,
-    '../serverless-appsync-plugin/example/',
     config.schema || 'schema.graphql',
   );
 


### PR DESCRIPTION
The previous merged PR #127, also made an addition to the `get-config.js` file which added a local path to the example project schema. Which was breaking deployments as the path to my schema.graphql file was pointing at `../serverless-appsync-plugin/example/`.

**Code Snippet causing issues:**
```
const schemaPath = path.join(
    servicePath,
    '../serverless-appsync-plugin/example/',
    config.schema || 'schema.graphql',
  );
```

**Needs to be:**
```
const schemaPath = path.join(
    servicePath,
    config.schema || 'schema.graphql',
  );
```
By deleting this addition, the deployments work again. You can test this break, by updating to the most recent version of the `serverless-appsync-plugin`.

**Break in deployment:**
<img width="561" alt="screen shot 2018-08-03 at 5 26 28 pm" src="https://user-images.githubusercontent.com/18511689/43670808-3c0c4b5a-9745-11e8-9fc4-56661e8c0bbb.png">

**Change made in #127:**
<img width="1667" alt="screen shot 2018-08-03 at 5 25 46 pm" src="https://user-images.githubusercontent.com/18511689/43670812-4d4ac3c4-9745-11e8-832c-109ce03276db.png">
