### PR TITLE
Add support of Serverless variables in velocity templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ custom:
         description: 'Http endpoint'
         config:
           endpoint: # required # "https://{DOMAIN}/{PATH}"
+    substitutions: # allows to pass variables from here to velocity templates
+      # ${exampleVar1} will be replaced with given value in all mapping templates
+      exampleVar1: "${self:service.name}"
+      exampleVar2: {'Fn::ImportValue': 'Some-external-stuff'}
 ```
 
 > Be sure to replace all variables that have been commented out, or have an empty value.

--- a/get-config.js
+++ b/get-config.js
@@ -42,6 +42,13 @@ module.exports = (config, provider, servicePath) => {
   if (config.logConfig && !config.logConfig.level) {
     throw new Error('logConfig property `level` must be NONE, ERROR, or ALL when logConfig exists.');
   }
+  // if (typeof config.substitutions === 'object') {
+  //   Object.values(config.substitutions).forEach((value) => {
+  //     if (typeof value === 'object') {
+  //       throw new Error('Currently only primitive types are supported for substitutions');
+  //     }
+  //   });
+  // }
 
   const mappingTemplatesLocation = config.mappingTemplatesLocation || 'mapping-templates';
   const mappingTemplates = config.mappingTemplates || [];
@@ -68,5 +75,6 @@ module.exports = (config, provider, servicePath) => {
     mappingTemplatesLocation,
     mappingTemplates,
     logConfig: config.logConfig,
+    substitutions: config.substitutions,
   };
 };

--- a/get-config.js
+++ b/get-config.js
@@ -42,13 +42,9 @@ module.exports = (config, provider, servicePath) => {
   if (config.logConfig && !config.logConfig.level) {
     throw new Error('logConfig property `level` must be NONE, ERROR, or ALL when logConfig exists.');
   }
-  // if (typeof config.substitutions === 'object') {
-  //   Object.values(config.substitutions).forEach((value) => {
-  //     if (typeof value === 'object') {
-  //       throw new Error('Currently only primitive types are supported for substitutions');
-  //     }
-  //   });
-  // }
+  if (config.substitutions && typeof config.substitutions !== 'object') {
+    throw new Error('substitutions property must be an object');
+  }
 
   const mappingTemplatesLocation = config.mappingTemplatesLocation || 'mapping-templates';
   const mappingTemplates = config.mappingTemplates || [];

--- a/index.js
+++ b/index.js
@@ -269,6 +269,7 @@ class ServerlessAppsyncPlugin {
   }
 
   processTemplate(template, config) {
+    // TODO use serverless variable parser and serverless variable syntax config
     const variableSyntax = RegExp(/\${([\w\d-_]+)}/g);
     const configVariables = Object.keys(config.substitutions);
     const templateVariables = [];
@@ -281,12 +282,10 @@ class ServerlessAppsyncPlugin {
     const substitutions = configVariables
       .filter(value => templateVariables.indexOf(value) > -1)
       .filter((value, index, array) => array.indexOf(value) === index)
-      .reduce((accum, value) => {
-        // accum[value] = config.substitutions[value];
-        //
-        // return accum;
-        return Object.assign(accum, { [value]: config.substitutions[value] });
-      }, {});
+      .reduce(
+        (accum, value) => Object.assign(accum, { [value]: config.substitutions[value] }),
+        {},
+      );
 
     // if there are substitutions for this template then add fn:sub
     if (Object.keys(substitutions).length > 0) {


### PR DESCRIPTION
It is more like a proposal since the current version does not leverage the full functionality of the serverless variables.

Here is a usage example:

add to the serverless.yml
```
appSync:
  ...
  substitutions:
    text: "some text"
    localVar: "${self:service.name}"
    externalVar: "${cf:${file(../serverless.yml):service.name}-${self:provider.stage}.UserPoolId}"
    CloudfrontVar: {'Fn::ImportValue': 'Some-external-stuff'}
```