### PR TITLE
Fix error when `substitutions` is omitted + fix Unit tests

### DIFF
--- a/__snapshots__/get-config.test.js.snap
+++ b/__snapshots__/get-config.test.js.snap
@@ -118,6 +118,7 @@ schema {
 }
 ",
   "serviceRoleArn": "1234",
+  "substitutions": Object {},
   "userPoolConfig": undefined,
 }
 `;

--- a/get-config.js
+++ b/get-config.js
@@ -68,6 +68,6 @@ module.exports = (config, provider, servicePath) => {
     mappingTemplatesLocation,
     mappingTemplates,
     logConfig: config.logConfig,
-    substitutions: config.substitutions,
+    substitutions: config.substitutions || {},
   };
 };

--- a/get-config.test.js
+++ b/get-config.test.js
@@ -1,7 +1,7 @@
 const getConfig = require('./get-config');
 const path = require('path');
 
-const servicePath = path.join(__dirname, '..', 'example');
+const servicePath = path.join(__dirname, 'example');
 
 test('authenticationType is missing', () => {
   const run = () => getConfig({}, {}, servicePath);

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "graphql": "^0.13.2",
     "ramda": "^0.25.0"
   },
-  "peerDependencies": {}
+  "peerDependencies": {},
+  "jest": {
+    "testEnvironment": "node"
+  }
 }


### PR DESCRIPTION
When the `substitutions` config is omitted, an error is thrown:

````
Cannot convert undefined or null to object
````

Also fixes Unit tests!

Also, May I suggest that we implement some kind of CI on this repo? e.g: circleci or travis ?