### PR TITLE
Clarify mapping template type field usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ custom:
     mappingTemplatesLocation: # defaults to mapping-templates
     mappingTemplates:
       - dataSource: # data source name
-        type: # Query, Mutation, Subscription
+        type: # type name in schema (e.g. Query, Mutation, Subscription)
         field: getUserInfo
         request: # request mapping template name
         response: # response mapping template name


### PR DESCRIPTION
Simple edit to documentation to clarify valid inputs for `type` field in `mappingTemplates`

Closes #110 