### PR TITLE
Add support for optional parameter appIdClientRegex in user pool config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ custom:
       awsRegion: # required # region
       defaultAction: # ALLOW
       userPoolId: # required # user pool ID
+      appIdClientRegex: # optional
       region: # defaults to provider region
     # if OPENID_CONNECT
     openIdConnectConfig:

--- a/index.js
+++ b/index.js
@@ -137,6 +137,7 @@ class ServerlessAppsyncPlugin {
             AwsRegion: config.region,
             DefaultAction: config.userPoolConfig.defaultAction,
             UserPoolId: config.userPoolConfig.userPoolId,
+            AppIdClientRegex: config.userPoolConfig.appIdClientRegex,
           },
           OpenIDConnectConfig: config.authenticationType !== 'OPENID_CONNECT' ? undefined : {
             Issuer: config.openIdConnectConfig.issuer,


### PR DESCRIPTION
Added support for the AppIdClientRegex parameter in the [AWS AppSync GraphQLApi UserPoolConfig](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appsync-graphqlapi-userpoolconfig.html).