### PR TITLE
Add support Multiple APIs

### DIFF
--- a/__snapshots__/get-config.test.js.snap
+++ b/__snapshots__/get-config.test.js.snap
@@ -5,27 +5,29 @@ exports[`authenticationType is missing 1`] = `"appSync property \`authentication
 exports[`authenticationType is missing 2`] = `"appSync property \`authenticationType\` is missing or invalid."`;
 
 exports[`returns valid config 1`] = `
-Object {
-  "apiId": undefined,
-  "apiKey": undefined,
-  "authenticationType": "AWS_IAM",
-  "dataSources": Array [
-    Object {
-      "name": "users",
-      "type": "AMAZON_DYNAMODB",
-    },
-    Object {
-      "name": "tweets",
-      "type": "AMAZON_DYNAMODB",
-    },
-  ],
-  "logConfig": undefined,
-  "mappingTemplates": Array [],
-  "mappingTemplatesLocation": "mapping-templates",
-  "name": "api",
-  "openIdConnectConfig": undefined,
-  "region": "us-east-1",
-  "schema": "type Mutation {
+Array [
+  Object {
+    "apiId": undefined,
+    "apiKey": undefined,
+    "authenticationType": "AWS_IAM",
+    "dataSources": Array [
+      Object {
+        "name": "users",
+        "type": "AMAZON_DYNAMODB",
+      },
+      Object {
+        "name": "tweets",
+        "type": "AMAZON_DYNAMODB",
+      },
+    ],
+    "isSingleConfig": true,
+    "logConfig": undefined,
+    "mappingTemplates": Array [],
+    "mappingTemplatesLocation": "mapping-templates",
+    "name": "api",
+    "openIdConnectConfig": undefined,
+    "region": "us-east-1",
+    "schema": "type Mutation {
 	# Create a tweet for a user
 	# consumer keys and tokens are not required for dynamo integration
 	createTweet(
@@ -119,7 +121,8 @@ schema {
 	subscription: Subscription
 }
 ",
-  "substitutions": Object {},
-  "userPoolConfig": undefined,
-}
+    "substitutions": Object {},
+    "userPoolConfig": undefined,
+  },
+]
 `;

--- a/get-config.js
+++ b/get-config.js
@@ -9,7 +9,7 @@ const objectToArrayWithNameProp = pipe(
   values,
 );
 
-module.exports = (config, provider, servicePath) => {
+const getConfig = (config, provider, servicePath) => {
   if (
     !(
       config.authenticationType === 'API_KEY' ||
@@ -64,4 +64,14 @@ module.exports = (config, provider, servicePath) => {
     logConfig: config.logConfig,
     substitutions: config.substitutions || {},
   };
+};
+
+module.exports = (config, provider, servicePath) => {
+  if (config.constructor === Array) {
+    return config.map(apiConfig => getConfig(apiConfig, provider, servicePath));
+  } else {
+    const singleConfig = getConfig(config, provider, servicePath);
+    singleConfig.isSingleConfig = true;
+    return [singleConfig];
+  }
 };

--- a/index.js
+++ b/index.js
@@ -345,8 +345,8 @@ class ServerlessAppsyncPlugin {
           ]
         }
       };
-      
-      return Object.assign({}, acc, { [this.getLogicalId(ds, RESOURCE_DATASOURCE_ROLE)]: resource });
+      // NOTE: No two AppSync APIs should share datasources. For potential fine-grain access implementation.
+      return Object.assign({}, acc, { [this.getLogicalId(config, this.getLogicalId(ds, RESOURCE_DATASOURCE_ROLE))]: resource });
     }, {});
   }
   
@@ -454,7 +454,7 @@ class ServerlessAppsyncPlugin {
       if (ds.config && ds.config.serviceRoleArn) {
         resource.Properties.ServiceRoleArn = ds.config.serviceRoleArn;
       } else {
-        const dataSourceRoleLogicalId = this.getLogicalId(ds, RESOURCE_DATASOURCE_ROLE);
+        const dataSourceRoleLogicalId = this.getLogicalId(config, this.getLogicalId(ds, RESOURCE_DATASOURCE_ROLE));
         // If a Role Resource was generated for this DataSource, use it
         const role = this.serverless.service.provider.compiledCloudFormationTemplate.Resources[dataSourceRoleLogicalId];
         if (role) {
@@ -484,7 +484,8 @@ class ServerlessAppsyncPlugin {
       } else if (ds.type !== 'NONE') {
         throw new this.serverless.classes.Error(`Data Source Type not supported: '${ds.type}`);
       }
-      return Object.assign({}, acc, { [this.getLogicalId(ds, RESOURCE_DATASOURCE)]: resource });
+      // NOTE: No two AppSync APIs should share datasources. For potential fine-grain access implementation.
+      return Object.assign({}, acc, { [this.getLogicalId(config, this.getLogicalId(ds, RESOURCE_DATASOURCE))]: resource });
     }, {});
   }
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,14 @@ const runPlayground = require('./graphql-playground');
 const getConfig = require('./get-config');
 
 const MIGRATION_DOCS = 'https://github.com/sid88in/serverless-appsync-plugin/blob/master/README.md#cfn-migration';
+const RESOURCE_API = "GraphQLApi";
+const RESOURCE_API_CLOUDWATCH_LOGS_ROLE = "GraphQlApiCloudWatchLogsRole";
+const RESOURCE_API_KEY = "GraphQlApiKey";
+const RESOURCE_SCHEMA = "GraphQlSchema";
+const RESOURCE_URL = "GraphQlApiUrl";
+const RESOURCE_RESOLVER = "GraphQlResolver";
+const RESOURCE_DATASOURCE = "GraphQlDs";
+const RESOURCE_DATASOURCE_ROLE = "GraphQlDsRole";
 
 class ServerlessAppsyncPlugin {
   constructor(serverless, options) {
@@ -65,7 +73,7 @@ class ServerlessAppsyncPlugin {
         + `is no longer supported. See ${MIGRATION_DOCS} for more information`);
     };
     this.hooks = {
-      'before:deploy:initialize': () => this.validateSchema(),
+      'before:deploy:initialize': () => this.validateSchemas(),
       'delete-appsync:delete': () => this.deleteGraphQLEndpoint(),
       'graphql-playground:run': () => this.runGraphqlPlayground(),
       'deploy-appsync:deploy': generateMigrationErrorMessage('deploy-appsync'),
@@ -82,8 +90,8 @@ class ServerlessAppsyncPlugin {
     );
   }
 
-  getSchema() {
-    const { schema } = this.loadConfig();
+  getSchemas() {
+    const config = this.loadConfig();
 
     const awsTypes = `
       scalar AWSDate
@@ -97,13 +105,22 @@ class ServerlessAppsyncPlugin {
       scalar AWSIPAddress
     `;
 
-    return `${schema} ${awsTypes}`;
+    return config.map(apiConfig => `${apiConfig.schema} ${awsTypes}`);
   }
 
-  validateSchema() {
-    const schema = this.getSchema();
-    const ast = buildASTSchema(parse(schema));
-    const errors = validateSchema(ast);
+  validateSchemas() {
+    const schemas = this.getSchemas();
+    const asts = schemas.map(schema => buildASTSchema(parse(schema)));
+    const errors = asts.reduce((accumulatedErrors, currentAst) => {
+      const currentErrors = validateSchema(currentAst);
+      if (!currentErrors.length) {
+        return accumulatedErrors;
+      } else if (!accumulatedErrors.length) {
+        return currentErrors;
+      } else {
+        return accumulatedErrors.concat(currentErrors || []);
+      }
+    });
     if (!errors.length) {
       return;
     }
@@ -111,32 +128,36 @@ class ServerlessAppsyncPlugin {
     errors.forEach((error) => {
       this.serverless.cli.log(printError(error));
     });
-    throw new this.serverless.classes.Error('Cannot proceed invalid graphql SDL');
+    throw new this.serverless.classes.Error('Cannot proceed invalid graphql SDL in one or more schemas.');
   }
 
   deleteGraphQLEndpoint() {
     const config = this.loadConfig();
-    const { apiId } = config;
-    if (!apiId) {
-      throw new this.serverless.classes.Error('serverless-appsync: no apiId is defined. If you are not '
-        + `migrating from a previous version of the plugin this is expected.  See ${MIGRATION_DOCS} '
-        + 'for more information`);
-    }
+    return Promise.all(config.map(apiConfig => {
+      const { apiId } = apiConfig;
+      if (!apiId) {
+        throw new this.serverless.classes.Error('serverless-appsync: no apiId is defined. If you are not '
+          + `migrating from a previous version of the plugin this is expected.  See ${MIGRATION_DOCS} `
+          + 'for more information');
+      }
 
-    this.serverless.cli.log('Deleting GraphQL Endpoint...');
-    return this.provider
-      .request('AppSync', 'deleteGraphqlApi', {
-        apiId,
-      })
-      .then((data) => {
-        if (data) {
-          this.serverless.cli.log(`Successfully deleted GraphQL Endpoint: ${apiId}`);
-        }
-      });
+      this.serverless.cli.log('Deleting GraphQL Endpoint...');
+      return this.provider
+        .request('AppSync', 'deleteGraphqlApi', {
+          apiId,
+        })
+        .then((data) => {
+          if (data) {
+            this.serverless.cli.log(`Successfully deleted GraphQL Endpoint: ${apiId}`);
+          }
+        });
+    }));
   }
 
   runGraphqlPlayground() {
-    runPlayground(this.serverless.service, this.provider, this.loadConfig(), this.options).then((url) => {
+    // Use the first config or config map
+    const config = this.loadConfig()[0];
+    runPlayground(this.serverless.service, this.provider, config, this.options).then((url) => {
       this.serverless.cli.log(`Graphql Playground Server Running at: ${url}`);
     });
   }
@@ -144,31 +165,35 @@ class ServerlessAppsyncPlugin {
   addResources() {
     const config = this.loadConfig();
 
-    if (config.apiId) {
-      this.serverless.cli.log('WARNING: serverless-appsync has been updated in a breaking way and your '
-        + 'service is configured using a reference to an existing apiKey in '
-        + '`custom.appSync` which is used in the legacy deploy scripts. This deploy will create '
-        + `new graphql resources and WILL NOT update your existing api. See ${MIGRATION_DOCS} for `
-        + 'more information');
-    }
-
     const resources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
-    Object.assign(resources, this.getGraphQlApiEndpointResource(config));
-    Object.assign(resources, this.getApiKeyResources(config));
-    Object.assign(resources, this.getGraphQLSchemaResource(config));
-    Object.assign(resources, this.getCloudWatchLogsRole(config));
-    Object.assign(resources, this.getDataSourceIamRolesResouces(config));
-    Object.assign(resources, this.getDataSourceResources(config));
-    Object.assign(resources, this.getResolverResources(config));
-
     const outputs = this.serverless.service.provider.compiledCloudFormationTemplate.Outputs;
-    Object.assign(outputs, this.getGraphQlApiOutputs(config));
-    Object.assign(outputs, this.getApiKeyOutputs(config));
+
+    config.forEach(apiConfig => {
+      if (apiConfig.apiId) {
+        this.serverless.cli.log('WARNING: serverless-appsync has been updated in a breaking way and your '
+          + 'service is configured using a reference to an existing apiKey in '
+          + '`custom.appSync` which is used in the legacy deploy scripts. This deploy will create '
+          + `new graphql resources and WILL NOT update your existing api. See ${MIGRATION_DOCS} for `
+          + 'more information');
+      }
+
+      Object.assign(resources, this.getGraphQlApiEndpointResource(apiConfig));
+      Object.assign(resources, this.getApiKeyResources(apiConfig));
+      Object.assign(resources, this.getGraphQLSchemaResource(apiConfig));
+      Object.assign(resources, this.getCloudWatchLogsRole(apiConfig));
+      Object.assign(resources, this.getDataSourceIamRolesResouces(apiConfig));
+      Object.assign(resources, this.getDataSourceResources(apiConfig));
+      Object.assign(resources, this.getResolverResources(apiConfig));
+
+      Object.assign(outputs, this.getGraphQlApiOutputs(apiConfig));
+      Object.assign(outputs, this.getApiKeyOutputs(apiConfig));
+    });
   }
 
   getGraphQlApiEndpointResource(config) {
+    const cloudWatchLogsRoleLogicalId = this.getLogicalId(config, RESOURCE_API_CLOUDWATCH_LOGS_ROLE);
     return {
-      GraphQlApi: {
+      [this.getLogicalId(config, RESOURCE_API)]: {
         Type: 'AWS::AppSync::GraphQLApi',
         Properties: {
           Name: config.name,
@@ -186,7 +211,8 @@ class ServerlessAppsyncPlugin {
             AuthTTL: config.openIdConnectConfig.authTTL,
           },
           LogConfig: !config.logConfig ? undefined : {
-            CloudWatchLogsRoleArn: config.logConfig.loggingRoleArn || { "Fn::GetAtt": ["GraphQlApiCloudWatchLogsRole", "Arn"] },
+            CloudWatchLogsRoleArn:
+              config.logConfig.loggingRoleArn || { "Fn::GetAtt": [cloudWatchLogsRoleLogicalId, "Arn"] },
             FieldLogLevel: config.logConfig.level,
           },
         },
@@ -199,11 +225,11 @@ class ServerlessAppsyncPlugin {
       return {};
     }
     return {
-      GraphQlApiKeyDefault: {
+      [this.getLogicalId(config, RESOURCE_API_KEY)]: {
         Type: 'AWS::AppSync::ApiKey',
         Properties: {
-          ApiId: { 'Fn::GetAtt': ['GraphQlApi', 'ApiId'] },
-          Description: 'serverless-appsync-plugin: Default',
+          ApiId: { 'Fn::GetAtt': [this.getLogicalId(config, RESOURCE_API), 'ApiId'] },
+          Description: `serverless-appsync-plugin: AppSync API Key for ${this.getLogicalId(config, RESOURCE_API_KEY)}`,
           Expires: Math.floor(Date.now() / 1000) + (365 * 24 * 60 * 60),
         },
       },
@@ -216,7 +242,7 @@ class ServerlessAppsyncPlugin {
     }
   
     return {
-      "GraphQlApiCloudWatchLogsRole": {
+      [this.getLogicalId(config, RESOURCE_API_CLOUDWATCH_LOGS_ROLE)]: {
         Type: 'AWS::IAM::Role',
         Properties: {
           "AssumeRolePolicyDocument": {
@@ -309,6 +335,7 @@ class ServerlessAppsyncPlugin {
           },
           Policies: [
             {
+              // TODO: Why are inline policies getting fine-grained policy names? There is no benefit to this.
               PolicyName: this.getDataSourceCfnName(ds.name) + "Policy",
               PolicyDocument: {
                 Version: "2012-10-17",
@@ -319,7 +346,7 @@ class ServerlessAppsyncPlugin {
         }
       };
       
-      return Object.assign({}, acc, { [this.getDataSourceCfnName(ds.name) + "Role"]: resource });
+      return Object.assign({}, acc, { [this.getLogicalId(ds, RESOURCE_DATASOURCE_ROLE)]: resource });
     }, {});
   }
   
@@ -416,22 +443,22 @@ class ServerlessAppsyncPlugin {
       const resource = {
         Type: 'AWS::AppSync::DataSource',
         Properties: {
-          ApiId: { 'Fn::GetAtt': ['GraphQlApi', 'ApiId'] },
+          ApiId: { 'Fn::GetAtt': [this.getLogicalId(config, RESOURCE_API), 'ApiId'] },
           Name: ds.name,
           Description: ds.description,
           Type: ds.type,
         },
       };
 
-      // If a serviceRoleArn was given for this DataAsouce, use it
+      // If a serviceRoleArn was given for this DataSource, use it
       if (ds.config && ds.config.serviceRoleArn) {
         resource.Properties.ServiceRoleArn = ds.config.serviceRoleArn;
       } else {
-        const roleResouceName = this.getDataSourceCfnName(ds.name) + "Role";
+        const dataSourceRoleLogicalId = this.getLogicalId(ds, RESOURCE_DATASOURCE_ROLE);
         // If a Role Resource was generated for this DataSource, use it
-        const role = this.serverless.service.provider.compiledCloudFormationTemplate.Resources[roleResouceName];
+        const role = this.serverless.service.provider.compiledCloudFormationTemplate.Resources[dataSourceRoleLogicalId];
         if (role) {
-          resource.Properties.ServiceRoleArn = { 'Fn::GetAtt': [roleResouceName, 'Arn'] }
+          resource.Properties.ServiceRoleArn = { 'Fn::GetAtt': [dataSourceRoleLogicalId, 'Arn'] }
         }
       }
       
@@ -457,17 +484,17 @@ class ServerlessAppsyncPlugin {
       } else if (ds.type !== 'NONE') {
         throw new this.serverless.classes.Error(`Data Source Type not supported: '${ds.type}`);
       }
-      return Object.assign({}, acc, { [this.getDataSourceCfnName(ds.name)]: resource });
+      return Object.assign({}, acc, { [this.getLogicalId(ds, RESOURCE_DATASOURCE)]: resource });
     }, {});
   }
 
   getGraphQLSchemaResource(config) {
     return {
-      GraphQlSchema: {
+      [this.getLogicalId(config, RESOURCE_SCHEMA)]: {
         Type: 'AWS::AppSync::GraphQLSchema',
         Properties: {
           Definition: config.schema,
-          ApiId: { 'Fn::GetAtt': ['GraphQlApi', 'ApiId'] },
+          ApiId: { 'Fn::GetAtt': [this.getLogicalId(config, RESOURCE_API), 'ApiId'] },
         },
       },
     };
@@ -481,14 +508,14 @@ class ServerlessAppsyncPlugin {
       const responseTemplate = fs.readFileSync(respTemplPath, 'utf8');
 
       return Object.assign({}, acc, {
-        [`GraphQlResolver${this.getCfnName(tpl.type)}${this.getCfnName(tpl.field)}`]: {
+        [`${this.getLogicalId(config, `${RESOURCE_RESOLVER}${tpl.type}${tpl.field}`)}`]: {
           Type: 'AWS::AppSync::Resolver',
-          DependsOn: 'GraphQlSchema',
+          DependsOn: this.getLogicalId(config, RESOURCE_SCHEMA),
           Properties: {
-            ApiId: { 'Fn::GetAtt': ['GraphQlApi', 'ApiId'] },
+            ApiId: { 'Fn::GetAtt': [this.getLogicalId(config, RESOURCE_API), 'ApiId'] },
             TypeName: tpl.type,
             FieldName: tpl.field,
-            DataSourceName: { 'Fn::GetAtt': [this.getDataSourceCfnName(tpl.dataSource), 'Name'] },
+            DataSourceName: { 'Fn::GetAtt': [this.getLogicalId({name: tpl.dataSource}, RESOURCE_DATASOURCE), 'Name'] },
             RequestMappingTemplate: this.processTemplate(requestTemplate, config),
             ResponseMappingTemplate: this.processTemplate(responseTemplate, config),
           },
@@ -497,10 +524,23 @@ class ServerlessAppsyncPlugin {
     }, {});
   }
 
-  getGraphQlApiOutputs() {
+  getLogicalId(config, resourceType) {
+    // Similar to serverless' implementation of functions
+    // (e.g. getUser becomes GetUserLambdaFunction for CloudFormation logical ID,
+    //  myService becomes MyServiceGraphQLApi or `MyService${resourceType}`)
+    if (config.isSingleConfig) {
+      // This will ensure people with CloudFormation stack dependencies on the previous
+      // version of the plugin doesn't break their {@code deleteGraphQLEndpoint} functionality
+        return this.getCfnName(resourceType);
+    } else {
+      return this.getCfnName(config.name[0].toUpperCase() + config.name.slice(1) + resourceType);
+    }
+  }
+
+  getGraphQlApiOutputs(config) {
     return {
-      GraphQlApiUrl: {
-        Value: { 'Fn::GetAtt': ['GraphQlApi', 'GraphQLUrl'] },
+      [this.getLogicalId(config, RESOURCE_URL)]: {
+        Value: { 'Fn::GetAtt': [this.getLogicalId(config, RESOURCE_API), 'GraphQLUrl'] },
       },
     };
   }
@@ -510,8 +550,8 @@ class ServerlessAppsyncPlugin {
       return {};
     }
     return {
-      GraphQlApiKeyDefault: {
-        Value: { 'Fn::GetAtt': ['GraphQlApiKeyDefault', 'ApiKey'] },
+      [this.getLogicalId(config, RESOURCE_API_KEY)]: {
+        Value: { 'Fn::GetAtt': [this.getLogicalId(config, RESOURCE_API_KEY), 'ApiKey'] },
       },
     };
   }

--- a/index.test.js
+++ b/index.test.js
@@ -9,7 +9,7 @@ beforeEach(() => {
   serverless = new Serverless();
   plugin = new  ServerlessAppsyncPlugin(serverless, {});
   config = {
-    name: 'api',
+    name: 'myApi',
     dataSources: [],
     region: 'us-east-1',
   };
@@ -29,7 +29,7 @@ describe("appsync config", () => {
     const role = plugin.getCloudWatchLogsRole(config);
     expect(role).toEqual(
       {
-        "GraphQlApiCloudWatchLogsRole": {
+        "MyApiGraphQlApiCloudWatchLogsRole": {
           Type: 'AWS::IAM::Role',
           Properties: {
             "AssumeRolePolicyDocument": {
@@ -173,7 +173,7 @@ describe("iamRoleStatements", () => {
     const roles = plugin.getDataSourceIamRolesResouces(config);
     expect(roles).toEqual(
       {
-        "GraphQlDsLambdaSourceRole": {
+        "MyApiLambdaSourceGraphQlDsRole": {
           "Type": "AWS::IAM::Role",
           "Properties": {
             "AssumeRolePolicyDocument": {
@@ -213,7 +213,7 @@ describe("iamRoleStatements", () => {
             ],
           },
         },
-        "GraphQlDsDynamoDbSourceRole": {
+        "MyApiDynamoDbSourceGraphQlDsRole": {
           "Type": "AWS::IAM::Role",
           "Properties": {
             "AssumeRolePolicyDocument": {
@@ -255,7 +255,7 @@ describe("iamRoleStatements", () => {
             ],
           },
         },
-        "GraphQlDsElasticSearchSourceRole": {
+        "MyApiElasticSearchSourceGraphQlDsRole": {
           "Type": "AWS::IAM::Role",
           "Properties": {
             "AssumeRolePolicyDocument": {
@@ -339,7 +339,7 @@ describe("iamRoleStatements", () => {
     const roles = plugin.getDataSourceIamRolesResouces(config);
     expect(roles).toEqual(
       {
-        "GraphQlDsLambdaSourceRole": {
+        "MyApiLambdaSourceGraphQlDsRole": {
           "Type": "AWS::IAM::Role",
           "Properties": {
             "AssumeRolePolicyDocument": {
@@ -388,7 +388,7 @@ describe("iamRoleStatements", () => {
             ],
           },
         },
-        "GraphQlDsDynamoDbSourceRole": {
+        "MyApiDynamoDbSourceGraphQlDsRole": {
           "Type": "AWS::IAM::Role",
           "Properties": {
             "AssumeRolePolicyDocument": {
@@ -453,7 +453,7 @@ describe("iamRoleStatements", () => {
             ],
           },
         },
-        "GraphQlDsElasticSearchSourceRole": {
+        "MyApiElasticSearchSourceGraphQlDsRole": {
           "Type": "AWS::IAM::Role",
           "Properties": {
             "AssumeRolePolicyDocument": {


### PR DESCRIPTION
This PR resolves:
- [#154 Feature Request/Discussion: Support for multiple APIs](https://github.com/sid88in/serverless-appsync-plugin/issues/154)
- [#135 Is it possible to deploy multiple API's form one serverless.yml](https://github.com/sid88in/serverless-appsync-plugin/issues/135)
- The second last paragraph of [this article](https://read.acloud.guru/deploy-a-graphql-service-on-aws-with-the-serverless-framework-7af8fc22a01d)

# What it does
Previously, deploying multiple APIs from this plugin was not possible, as the appSync plugin only allows for an `Object` configuration within the custom.appSync variable:
``` yaml
custom:
  appSync:
    name: all-in-one-appsync-endpoint-yikes
    schema: AppSync/schema.graphql
    authenticationType: OPENID_CONNECT
    openIdConnectConfig:
    ...
    serviceRole: AllInOneServiceRole
    dataSources:
    ...
    mappingTemplatesLocation: ...
    mappingTemplates:
    ...
```
This PR adds support for a variable of type `Array` to support deployment to multiple AppSync APIs.
```yaml
custom:
  appSync:
    - name: authenticated-appsync-endpoint
      schema: AppSync/schema.graphql # or something like AppSync/private/schema.graphql
      authenticationType: OPENID_CONNECT
      openIdConnectConfig:
      ...
      serviceRole: AuthenticatedAppSyncServiceRole
      dataSources:
      ...
      mappingTemplatesLocation: ...
      mappingTemplates:
      ...
    - name: public-appsync-endpoint
      schema: AppSync/schema.graphql # or something like AppSync/public/schema.graphql
      authenticationType: NONE # or API_KEY, you get the idea
      serviceRole: PublicAppSyncServiceRole
      dataSources:
      ...
      mappingTemplatesLocation: ...
      mappingTemplates:
      ...
```
# Does it break anything?
No. The old `Object` setup still works fine. If a map/ `Object` is provided in the config, the logicalId of the appsync API remains as `GraphQlApi`.
# Caveats
1. `deleteGraphQLEndpoint` functionality that helps to retain existing API key and URLs will continue to work if setups are maps but will change once names are changed, as per AWS CloudFormation docs.
2. Resources dependent on any existing roles, policies, datasources or resolvers generated by the plugin, will be updated to match Serverless' naming convention. That is,
   - `GraphQlDs<DATASOURCE>` > `<DATASOURCE>GraphQlDs`
   - `GraphQlResolver<RESOLVER>` > `<RESOLVER>GraphQlResolver`
   - `GraphQlDs<DATASOURCE>Role` > `<DATASOURCE>GraphQlDsRole`
