### PR TITLE
Remove unused `accountId` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Add the following example config to the custom section of ```serverless.yml```
 
 ```yaml
 custom:
-  accountId: abc # found here https://console.aws.amazon.com/billing/home?#/account
   appSync:
     name:  # defaults to api
     # apiKey # only required for update-appsync/delete-appsync

--- a/index.js
+++ b/index.js
@@ -247,10 +247,9 @@ class ServerlessAppsyncPlugin {
                     "Resource": [
                       {
                         "Fn::Sub" : [
-                          "arn:aws:logs:${region}:${accountId}:*",
+                          "arn:aws:logs:${region}:${AWS::AccountId}:*",
                           {
-                            region: config.region,
-                            accountId: { "Ref" : "AWS::AccountId" },
+                            region: config.region
                           }
                         ]
                       }

--- a/index.test.js
+++ b/index.test.js
@@ -60,10 +60,9 @@ describe("appsync config", () => {
                       "Resource": [
                         {
                           "Fn::Sub" : [
-                            "arn:aws:logs:${region}:${accountId}:*",
+                            "arn:aws:logs:${region}:${AWS::AccountId}:*",
                             {
-                              region: 'us-east-1',
-                              accountId: { "Ref" : "AWS::AccountId" },
+                              region: 'us-east-1'
                             }
                           ]
                         }


### PR DESCRIPTION
Everywhere that needed an account ID was using the AWS::AccountId
pseudo-parameter [1] instead.

[1] https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html