### PR TITLE
Update multiple APIs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,37 @@ custom:
 
 > Be sure to replace all variables that have been commented out, or have an empty value.
 
+#### Multiple APIs
+
+If you have multiple APIs and do not want to split this up into another CloudFormation stack, simply change the `appSync` configuration property from an object into an array of objects:
+
+```yaml
+custom:
+  appSync:
+    - name: private-appsync-endpoint
+      schema: AppSync/schema.graphql # or something like AppSync/private/schema.graphql
+      authenticationType: OPENID_CONNECT
+      openIdConnectConfig:
+      ...
+      serviceRole: AuthenticatedAppSyncServiceRole
+      dataSources:
+      ...
+      mappingTemplatesLocation: ...
+      mappingTemplates:
+      ...
+    - name: public-appsync-endpoint
+      schema: AppSync/schema.graphql # or something like AppSync/public/schema.graphql
+      authenticationType: NONE # or API_KEY, you get the idea
+      serviceRole: PublicAppSyncServiceRole
+      dataSources:
+      ...
+      mappingTemplatesLocation: ...
+      mappingTemplates:
+      ...
+```
+
+> Note: CloudFormation stack outputs and logical IDs will be changed from the defaults to api name prefixed. This allows you to differentiate the APIs on your stack if you want to work with multiple APIs.
+
 ## ▶️ Usage
 
 ### `serverless deploy`

--- a/__snapshots__/get-config.test.js.snap
+++ b/__snapshots__/get-config.test.js.snap
@@ -19,6 +19,7 @@ Object {
       "type": "AMAZON_DYNAMODB",
     },
   ],
+  "isSingleConfig": true,
   "logConfig": undefined,
   "mappingTemplates": Array [],
   "mappingTemplatesLocation": "mapping-templates",

--- a/get-config.js
+++ b/get-config.js
@@ -9,7 +9,7 @@ const objectToArrayWithNameProp = pipe(
   values,
 );
 
-module.exports = (config, provider, servicePath) => {
+const getConfig = (config, provider, servicePath) => {
   if (
     !(
       config.authenticationType === 'API_KEY' ||
@@ -64,4 +64,16 @@ module.exports = (config, provider, servicePath) => {
     logConfig: config.logConfig,
     substitutions: config.substitutions || {},
   };
+};
+
+module.exports = (config, provider, servicePath) => {
+  if (!config) {
+    return [];
+  } else if (config.constructor === Array) {
+    return config.map(apiConfig => getConfig(apiConfig, provider, servicePath));
+  } else {
+    const singleConfig = getConfig(config, provider, servicePath);
+    singleConfig.isSingleConfig = true;
+    return [singleConfig];
+  }
 };

--- a/get-config.test.js
+++ b/get-config.test.js
@@ -34,5 +34,5 @@ test('returns valid config', () => {
     },
     { region: 'us-east-1' },
     servicePath,
-  )).toMatchSnapshot();
+  )[0]).toMatchSnapshot();
 });

--- a/index.test.js
+++ b/index.test.js
@@ -12,6 +12,7 @@ beforeEach(() => {
     name: 'api',
     dataSources: [],
     region: 'us-east-1',
+    isSingleConfig: true,
   };
 });
 


### PR DESCRIPTION
Fixed CloudFormation logicalId changes to prevent migration issues. Please run tests before merging to see if they are satiable to your standards. This should now stop all previous versions of the plugin from deleting resources.