### PR TITLE
Use a different hook for adding resources to allow sls package and the use of other plugins (e.g. split stacks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Tired of 🚀 **deploying**, ✏️ **updating**, and ❌ **deleting** your AppS
 * [Getting Started](#-getting-started)
 * [Installation](#-installation)
 * [Usage](#️-usage)
+* [Notes](#-notes)
+    * [Offline Support](#offline-support)
+    * [Split Stacks Plugin](#split-stacks-plugin)
 * [Contributing](#-contributing)
 * [Credits](#️-credits)
 </details>
@@ -79,10 +82,10 @@ custom:
       region: # defaults to provider region
     # if OPENID_CONNECT
     openIdConnectConfig:
-      issuer: 
-      clientId: 
-      iatTTL: 
-      authTTL: 
+      issuer:
+      clientId:
+      iatTTL:
+      authTTL:
     logConfig:
       loggingRoleArn: { Fn::GetAtt: [AppSyncLoggingServiceRole, Arn] } # Where AppSyncLoggingServiceRole is a role with CloudWatch Logs write access
       level: ERROR # Logging Level: NONE | ERROR | ALL
@@ -108,7 +111,7 @@ custom:
               Resource:
                 - "arn:aws:dynamodb:{REGION}:{ACCOUNT_ID}:myTable"
                 - "arn:aws:dynamodb:{REGION}:{ACCOUNT_ID}:myTable/*"
-              
+
           region: # Overwrite default region for this data source
       - type: AMAZON_ELASTICSEARCH
         name: # data source name
@@ -170,12 +173,12 @@ The AWS_IAM authenticationType is not currently supported.
 
 * If you are planning on using <a target="_blank" href="https://aws.amazon.com/elasticsearch-service">AWS Elastic Search</a>, you will need to create an Elastic Search domain/endpoint on AWS and set it as the ```endpoint``` option in  ```serverless.yml``` **before** deploying.
 
-## Offline support
+### Offline support
 
 You can use [serverless-appsync-offline](https://github.com/aheissenberger/serverless-appsync-offline) to autostart an [AppSync Emulator](https://github.com/ConduitVC/aws-utils/tree/appsync/packages/appsync-emulator-serverless) which depends on [Serverless-AppSync-Plugin](https://github.com/sid88in/serverless-appsync-plugin) with DynamoDB and Lambda resolver support:
-### Install Plugin
+#### Install Plugin
 `npm install --save serverless-appsync-offline`
-### Minimal Options (serverless.yml)
+#### Minimal Options (serverless.yml)
 ```yml
 custom:
   appsync-offline:
@@ -184,7 +187,7 @@ custom:
       server:
         port: 8000
 ```
-### Start local enviroment
+#### Start local enviroment
 
 If you use `serverless-offline`:
 
@@ -202,6 +205,42 @@ Serverless: AppSync started: http://localhost:62222/graphql
 ```
 
 Go to [serverless-appsync-offline](https://github.com/aheissenberger/serverless-appsync-offline) to get further configuration options.
+
+### Split Stacks Plugin
+
+You can use [serverless-plugin-split-stacks](https://github.com/dougmoscrop/serverless-plugin-split-stacks) to migrate AppSync resources in nested stacks in order to work around the 200 resource limit.
+
+1. Install [serverless-plugin-split-stacks](https://github.com/dougmoscrop/serverless-plugin-split-stacks)
+
+```
+yarn add --dev serverless-plugin-split-stacks
+# or
+npm install --save-dev serverless-plugin-split-stacks
+```
+
+2. Follow the `serverless-plugin-split-stacks` installation instructions
+
+3. Place `serverless-plugin-split-stacks` after `serverless-appsync-plugin`
+
+```yml
+plugins:
+  - serverless-appsync-plugin
+  - serverless-plugin-split-stacks
+```
+
+4. Create `stacks-map.js` in the root folder
+
+```js
+module.exports = {
+  'AWS::AppSync::ApiKey': { destination: 'AppSync', allowSuffix: true },
+  'AWS::AppSync::DataSource': { destination: 'AppSync', allowSuffix: true },
+  'AWS::AppSync::GraphQLApi': { destination: 'AppSync', allowSuffix: true },
+  'AWS::AppSync::GraphQLSchema': { destination: 'AppSync', allowSuffix: true },
+  'AWS::AppSync::Resolver': { destination: 'AppSync', allowSuffix: true }
+}
+```
+
+5. Enjoy :beers:
 
 ## 🎁 Contributing
 

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ class ServerlessAppsyncPlugin {
       'graphql-playground:run': () => this.runGraphqlPlayground(),
       'deploy-appsync:deploy': generateMigrationErrorMessage('deploy-appsync'),
       'update-appsync:update': generateMigrationErrorMessage('update-appsync'),
-      'before:deploy:deploy': () => this.addResources(),
+      'after:aws:package:finalize:mergeCustomProviderResources': () => this.addResources(),
     };
   }
 


### PR DESCRIPTION
We got the same issue as https://github.com/sid88in/serverless-appsync-plugin/issues/144

After doing some investigations, we found that by changing the hook event in appsync plugin, it will allow the [split stacks plugin](https://github.com/dougmoscrop/serverless-plugin-split-stacks) to work

`stacks-map.js` used by the split stacks plugin

```js
module.exports = {
  'AWS::AppSync::ApiKey': { destination: 'AppSync', allowSuffix: true },
  'AWS::AppSync::DataSource': { destination: 'AppSync', allowSuffix: true },
  'AWS::AppSync::GraphQLApi': { destination: 'AppSync', allowSuffix: true },
  'AWS::AppSync::GraphQLSchema': { destination: 'AppSync', allowSuffix: true },
  'AWS::AppSync::Resolver': { destination: 'AppSync', allowSuffix: true }
}
```

![image 4](https://user-images.githubusercontent.com/1476974/48102241-e7095680-e275-11e8-8c7e-79e930aba081.png)

After deploy

![image](https://user-images.githubusercontent.com/1476974/48102349-5c752700-e276-11e8-93eb-38d393d32712.png)

We also tested the deployed appsync and it all works perfectly.

One more benefit of this change is that doing `serverless package` will now include the resource added by the AppSync plugin so it is easier to debug.

Some generated AppSync resources in `cloudformation-template-update-stack.json` after running `serverless package`.

![image](https://user-images.githubusercontent.com/1476974/48102588-83802880-e277-11e8-903a-32ce24d606b7.png)