### PR TITLE
Issue 178: userPoolConfig in different region does not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ custom:
     authenticationType: API_KEY or AWS_IAM or AMAZON_COGNITO_USER_POOLS or OPENID_CONNECT
     # if AMAZON_COGNITO_USER_POOLS
     userPoolConfig:
-      awsRegion: # required # defaults to provider region
+      awsRegion: # defaults to provider region
       defaultAction: # ALLOW
       userPoolId: # required # user pool ID
       appIdClientRegex: # optional

--- a/README.md
+++ b/README.md
@@ -75,11 +75,10 @@ custom:
     authenticationType: API_KEY or AWS_IAM or AMAZON_COGNITO_USER_POOLS or OPENID_CONNECT
     # if AMAZON_COGNITO_USER_POOLS
     userPoolConfig:
-      awsRegion: # required # region
+      awsRegion: # required # defaults to provider region
       defaultAction: # ALLOW
       userPoolId: # required # user pool ID
       appIdClientRegex: # optional
-      region: # defaults to provider region
     # if OPENID_CONNECT
     openIdConnectConfig:
       issuer:

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -20,10 +20,9 @@ custom:
     # name:  # defaults to api
     authenticationType: AMAZON_COGNITO_USER_POOLS
     userPoolConfig:
-      awsRegion: # required # region
+      awsRegion: # defaults to provider region
       defaultAction: # ALLOW
       userPoolId: # required # user pool ID
-    # region: # defaults to provider region
     # mappingTemplatesLocation: # defaults to mapping-templates
     mappingTemplates:
       - dataSource: Users

--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ class ServerlessAppsyncPlugin {
           Name: config.name,
           AuthenticationType: config.authenticationType,
           UserPoolConfig: config.authenticationType !== 'AMAZON_COGNITO_USER_POOLS' ? undefined : {
-            AwsRegion: config.region,
+            AwsRegion: config.userPoolConfig.awsRegion || config.region,
             DefaultAction: config.userPoolConfig.defaultAction,
             UserPoolId: config.userPoolConfig.userPoolId,
             AppIdClientRegex: config.userPoolConfig.appIdClientRegex,


### PR DESCRIPTION
Allow userPoolConfig region to override the region specified in the provider section.