### PR TITLE
Pipeline resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,41 @@ custom:
 
 > Note: CloudFormation stack outputs and logical IDs will be changed from the defaults to api name prefixed. This allows you to differentiate the APIs on your stack if you want to work with multiple APIs.
 
+#### Pipeline Resolvers
+
+Amazon recently released the new pipeline resolvers:
+https://aws.amazon.com/blogs/mobile/aws-appsync-releases-pipeline-resolvers-aurora-serverless-support-delta-sync/
+
+These changes allow you to perform more than one mapping template in sequence, so you can do multiple queries to multiple sources.
+These queries are called function configurations ('AWS::AppSync::FunctionConfiguration') and are children of a resolver.
+
+Here is an example of how to configure a resolver with function configurations.
+The key here is to provide a 'kind' of 'PIPELINE' to the mapping template of the parent resolver.
+Then provide the names of the functions in the mappingTemplate to match the names of the functionConfigurations.
+
+```
+custom:
+  appSync: 
+    mappingTemplates:
+      - type: Query
+        field: testPipelineQuery
+        request: 'start.vtl'
+        response: 'common-response.vtl'
+        kind: PIPELINE
+        functions:
+          - authorizeFunction 
+          - fetchDataFunction
+    functionConfigurations:
+      - dataSource: graphqlLambda
+        name: 'authorizeFunction'
+        request: './mapping-templates/authorize-request.vtl'
+        response: './mapping-templates/common-response.vtl'
+      - dataSource: dataTable
+        name: 'fetchDataFunction'
+        request: './mapping-templates/fetchData.vtl'
+        response: './mapping-templates/common-response.vtl'
+```
+
 ## ▶️ Usage
 
 ### `serverless deploy`

--- a/__snapshots__/get-config.test.js.snap
+++ b/__snapshots__/get-config.test.js.snap
@@ -19,6 +19,8 @@ Object {
       "type": "AMAZON_DYNAMODB",
     },
   ],
+  "functionConfigurations": Array [],
+  "functionConfigurationsLocation": "function-configurations",
   "isSingleConfig": true,
   "logConfig": undefined,
   "mappingTemplates": Array [],

--- a/get-config.js
+++ b/get-config.js
@@ -34,7 +34,9 @@ const getConfig = (config, provider, servicePath) => {
     throw new Error('substitutions property must be an object');
   }
 
+  const functionConfigurationsLocation = config.functionConfigurationsLocation || 'functionConfigurations';
   const mappingTemplatesLocation = config.mappingTemplatesLocation || 'mapping-templates';
+  const functionConfigurations = config.functionConfigurations || 'functionConfigurations';
   const mappingTemplates = config.mappingTemplates || [];
 
   const schemaPath = path.join(
@@ -61,6 +63,8 @@ const getConfig = (config, provider, servicePath) => {
     dataSources,
     mappingTemplatesLocation,
     mappingTemplates,
+    functionConfigurationsLocation,
+    functionConfigurations,
     logConfig: config.logConfig,
     substitutions: config.substitutions || {},
   };

--- a/get-config.js
+++ b/get-config.js
@@ -34,9 +34,9 @@ const getConfig = (config, provider, servicePath) => {
     throw new Error('substitutions property must be an object');
   }
 
-  const functionConfigurationsLocation = config.functionConfigurationsLocation || 'functionConfigurations';
+  const functionConfigurationsLocation = config.functionConfigurationsLocation || 'function-configurations';
   const mappingTemplatesLocation = config.mappingTemplatesLocation || 'mapping-templates';
-  const functionConfigurations = config.functionConfigurations || 'functionConfigurations';
+  const functionConfigurations = config.functionConfigurations || 'function-configurations';
   const mappingTemplates = config.mappingTemplates || [];
 
   const schemaPath = path.join(

--- a/get-config.js
+++ b/get-config.js
@@ -36,7 +36,7 @@ const getConfig = (config, provider, servicePath) => {
 
   const functionConfigurationsLocation = config.functionConfigurationsLocation || 'function-configurations';
   const mappingTemplatesLocation = config.mappingTemplatesLocation || 'mapping-templates';
-  const functionConfigurations = config.functionConfigurations || 'function-configurations';
+  const functionConfigurations = config.functionConfigurations || [];
   const mappingTemplates = config.mappingTemplates || [];
 
   const schemaPath = path.join(

--- a/index.js
+++ b/index.js
@@ -181,6 +181,7 @@ class ServerlessAppsyncPlugin {
       Object.assign(resources, this.getCloudWatchLogsRole(apiConfig));
       Object.assign(resources, this.getDataSourceIamRolesResouces(apiConfig));
       Object.assign(resources, this.getDataSourceResources(apiConfig));
+      Object.assign(resources, this.getFunctionConfigurationResources(apiConfig));
       Object.assign(resources, this.getResolverResources(apiConfig));
 
       Object.assign(outputs, this.getGraphQlApiOutputs(apiConfig));
@@ -505,7 +506,35 @@ class ServerlessAppsyncPlugin {
       },
     };
   }
+  getFunctionConfigurationResources(config) {
+    return config.functionConfigurations.reduce((acc, tpl) => {
+      const reqTemplPath = path.join(config.mappingTemplatesLocation, tpl.request);
+      const respTemplPath = path.join(config.mappingTemplatesLocation, tpl.response);
+      const requestTemplate = fs.readFileSync(reqTemplPath, 'utf8');
+      const responseTemplate = fs.readFileSync(respTemplPath, 'utf8');
 
+      const logicalIdGraphQLApi = this.getLogicalId(config, RESOURCE_API);
+      const logicalIdFunctionConfiguration = this.getLogicalId(
+        config,
+        `GraphQlFunctionConfiguration${this.getCfnName(tpl.name)}`
+      );
+      const logicalIdDataSource = this.getLogicalId(config, this.getDataSourceCfnName(tpl.dataSource));
+      return Object.assign({}, acc, {
+        [logicalIdFunctionConfiguration]: {
+          Type: 'AWS::AppSync::FunctionConfiguration',
+          Properties: {
+            ApiId: { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
+            Name: logicalIdFunctionConfiguration,
+            DataSourceName: { 'Fn::GetAtt': [logicalIdDataSource, 'Name'] },
+            RequestMappingTemplate: this.processTemplate(requestTemplate, config),
+            ResponseMappingTemplate: this.processTemplate(responseTemplate, config),
+            FunctionVersion: '2018-05-29'
+          }
+        }
+      });
+    }, {});
+  }
+  
   getResolverResources(config) {
     return config.mappingTemplates.reduce((acc, tpl) => {
       const reqTemplPath = path.join(config.mappingTemplatesLocation, tpl.request);
@@ -519,6 +548,32 @@ class ServerlessAppsyncPlugin {
         config,
         `GraphQlResolver${this.getCfnName(tpl.type)}${this.getCfnName(tpl.field)}`
       );
+      if (tpl.kind === 'PIPELINE') {
+        return Object.assign({}, acc, {
+          [logicalIdResolver]: {
+            Type: 'AWS::AppSync::Resolver',
+            DependsOn: logicalIdGraphQLSchema,
+            Properties: {
+              ApiId: { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
+              TypeName: tpl.type,
+              FieldName: tpl.field,
+              RequestMappingTemplate: this.processTemplate(requestTemplate, config),
+              ResponseMappingTemplate: this.processTemplate(responseTemplate, config),
+              Kind: 'PIPELINE',
+              PipelineConfig: {
+                Functions: tpl.functions.map(functionAttributeName => {
+                  const logicalIdDataSource = this.getLogicalId(
+                    config,
+                    `GraphQlFunctionConfiguration${this.getCfnName(functionAttributeName)}`
+                  );
+                  return { 'Fn::GetAtt': [logicalIdDataSource, 'FunctionId'] };
+                })
+              }
+            }
+          }
+        });
+      }
+
       const logicalIdDataSource = this.getLogicalId(config, this.getDataSourceCfnName(tpl.dataSource));
       return Object.assign({}, acc, {
         [logicalIdResolver]: {


### PR DESCRIPTION
Hi,
Amazon recently released the new pipeline resolvers: 
https://aws.amazon.com/blogs/mobile/aws-appsync-releases-pipeline-resolvers-aurora-serverless-support-delta-sync/ 

https://github.com/lkhari and I made these changes to allow for configuring a resolver with a pipeline.

The syntax to test it is: 
```
appSync: 
  mappingTemplates:
    - type: Query
          field: testPipelineQuery
          request: 'start.vtl'
          response: 'common-response.vtl'
          kind: PIPELINE
          functions:
            - authorizeFunction 
            - fetchDataFunction
  functionConfigurations:
    - dataSource: graphqlLambda
          name: 'authorizeFunction'
          request: '../mapping-templates/authorize-request.vtl'
          response: '../mapping-templates/common-response.vtl'
    - dataSource: dataTable
          name: 'fetchDataFunction'
          request: '../mapping-templates/fetchData.vtl'
          response: '../mapping-templates/common-response.vtl'
```