### PR TITLE
Allow for nested Mapping Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ custom:
         field: getUserInfo
         request: # request mapping template name
         response: # response mapping template name
+      - ${file({fileLocation}.yml)} # link to a file with arrays of mapping templates
     schema: # defaults schema.graphql
     dataSources:
       - type: AMAZON_DYNAMODB

--- a/index.js
+++ b/index.js
@@ -509,7 +509,8 @@ class ServerlessAppsyncPlugin {
     };
   }
   getFunctionConfigurationResources(config) {
-    return config.functionConfigurations.reduce((acc, tpl) => {
+    const flattenedFunctionConfigurationResources = config.functionConfigurations.reduce((accumulator, currentValue) => accumulator.concat(currentValue), []);
+    return flattenedFunctionConfigurationResources.reduce((acc, tpl) => {
       const reqTemplPath = path.join(config.mappingTemplatesLocation, tpl.request);
       const respTemplPath = path.join(config.mappingTemplatesLocation, tpl.response);
       const requestTemplate = fs.readFileSync(reqTemplPath, 'utf8');

--- a/index.js
+++ b/index.js
@@ -509,7 +509,8 @@ class ServerlessAppsyncPlugin {
   }
 
   getResolverResources(config) {
-    return config.mappingTemplates.reduce((acc, tpl) => {
+    const flattenedMappingTemplates = config.mappingTemplates.reduce((accumulator, currentValue) => accumulator.concat(currentValue), []);
+    return flattenedMappingTemplates.reduce((acc, tpl) => {
       const reqTemplPath = path.join(config.mappingTemplatesLocation, tpl.request);
       const respTemplPath = path.join(config.mappingTemplatesLocation, tpl.response);
       const requestTemplate = fs.readFileSync(reqTemplPath, 'utf8');


### PR DESCRIPTION
In order to reduce the large file containing all mapping templates I have made this change to allow multiple file inputs. 

I am flattening the input mapping templates into a single array. 
This is tested with 

- array of multiple files
- array of files and mappingtemplates
- nothing
- array of mappingtemplates

I don't believe it will work with files in files though.

Usage example
``` 
  appSync:
    mappingTemplates:
      - ${file(mapping-templates/queries.yml)}
      - ${file(mapping-templates/mutation.yml)}
```