### PR TITLE
Allow batch DynamoDB operations with default role

### DIFF
--- a/index.js
+++ b/index.js
@@ -382,6 +382,8 @@ class ServerlessAppsyncPlugin {
           "dynamodb:Query",
           "dynamodb:Scan",
           "dynamodb:UpdateItem",
+          "dynamodb:BatchGetItem",
+          "dynamodb:BatchWriteItem"
         ];
 
         const resourceArn = {

--- a/index.test.js
+++ b/index.test.js
@@ -422,6 +422,8 @@ describe("iamRoleStatements", () => {
                         "dynamodb:Query",
                         "dynamodb:Scan",
                         "dynamodb:UpdateItem",
+                        "dynamodb:BatchGetItem",
+                        "dynamodb:BatchWriteItem"
                       ],
                       "Resource": [
                         { "Fn::Join" : [ ":", [


### PR DESCRIPTION
The BatchGetItem operation is not permitted with default IAM role for DynamoDB, I am not quite sure why.
This adds two allowed actions: `dynamodb:BatchWriteItem` and `dynamodb:BatchGetItem`.