### PR TITLE
 Handle a scenario where value is undefined

### DIFF
--- a/get-stack-value.js
+++ b/get-stack-value.js
@@ -5,7 +5,7 @@ function getServerlessStackName(service, provider) {
 function getValue(service, provider, value, name) {
   if (typeof value === 'string') {
     return Promise.resolve(value);
-  } else if (typeof value.Ref === 'string') {
+  } else if (value && typeof value.Ref === 'string') {
     return provider
       .request(
         'CloudFormation',

--- a/get-stack-value.js
+++ b/get-stack-value.js
@@ -3,30 +3,28 @@ function getServerlessStackName(service, provider) {
 }
 
 function getValue(service, provider, value, name) {
-  if (typeof value === "string") {
+  if (typeof value === 'string') {
     return Promise.resolve(value);
-  } else if (typeof value.Ref === "string") {
+  } else if (typeof value.Ref === 'string') {
     return provider
       .request(
-        "CloudFormation",
-        "listStackResources",
+        'CloudFormation',
+        'listStackResources',
         {
-          StackName: getServerlessStackName(service, provider)
+          StackName: getServerlessStackName(service, provider),
         },
       )
-      .then(result => {
-        const resource = result.StackResourceSummaries.find(
-          r => r.LogicalResourceId === value.Ref
-        );
+      .then((result) => {
+        const resource = result.StackResourceSummaries.find(r => r.LogicalResourceId === value.Ref);
         if (!resource) {
           throw new Error(`${name}: Ref "${value.Ref} not found`);
         }
 
         return resource.PhysicalResourceId;
       });
-  } else {
-    return Promise.reject(`${value} is not a valid ${name}`);
   }
+
+  return Promise.reject(new Error(`${value} is not a valid ${name}`));
 }
 
 module.exports = {


### PR DESCRIPTION
Not setting the `userPoolConfig.playgroundClientId` in the .yml threw a non descriptive error:

![screenshot 2019-01-11 at 14 36 12](https://user-images.githubusercontent.com/142531/51036727-49e8d800-15ae-11e9-914f-030e46a3312e.png)

With this PR new error in the console is:

![screenshot 2019-01-11 at 14 36 22](https://user-images.githubusercontent.com/142531/51036733-510fe600-15ae-11e9-9299-b19ec8583b8d.png)
