### PR TITLE
Add default filename conventions for mappingTemplates

### DIFF
--- a/index.js
+++ b/index.js
@@ -522,8 +522,8 @@ class ServerlessAppsyncPlugin {
   getFunctionConfigurationResources(config) {
     const flattenedFunctionConfigurationResources = config.functionConfigurations.reduce((accumulator, currentValue) => accumulator.concat(currentValue), []);
     return flattenedFunctionConfigurationResources.reduce((acc, tpl) => {
-      const reqTemplPath = path.join(config.mappingTemplatesLocation, tpl.request);
-      const respTemplPath = path.join(config.mappingTemplatesLocation, tpl.response);
+      const reqTemplPath = path.join(config.mappingTemplatesLocation, tpl.request || `${tpl.type}.${tpl.field}.request.vtl`);
+      const respTemplPath = path.join(config.mappingTemplatesLocation, tpl.response || `${tpl.type}.${tpl.field}.response.vtl`);
       const requestTemplate = fs.readFileSync(reqTemplPath, 'utf8');
       const responseTemplate = fs.readFileSync(respTemplPath, 'utf8');
 

--- a/index.js
+++ b/index.js
@@ -553,8 +553,8 @@ class ServerlessAppsyncPlugin {
   getResolverResources(config) {
     const flattenedMappingTemplates = config.mappingTemplates.reduce((accumulator, currentValue) => accumulator.concat(currentValue), []);
     return flattenedMappingTemplates.reduce((acc, tpl) => {
-      const reqTemplPath = path.join(config.mappingTemplatesLocation, tpl.request);
-      const respTemplPath = path.join(config.mappingTemplatesLocation, tpl.response);
+      const reqTemplPath = path.join(config.mappingTemplatesLocation, tpl.request || `${tpl.type}.${tpl.field}.request.vtl`);
+      const respTemplPath = path.join(config.mappingTemplatesLocation, tpl.response || `${tpl.type}.${tpl.field}.response.vtl`);
       const requestTemplate = fs.readFileSync(reqTemplPath, 'utf8');
       const responseTemplate = fs.readFileSync(respTemplPath, 'utf8');
 


### PR DESCRIPTION
# Problem
When specifying mapping-templates in `serverless.yml`, the file gets very big very fast.
In most cases, the user wants to use the same structure and naming conventions for all requests and response template. 

# Solution 
If request and response is omitted a default naming convention will be used instead:
`{Type}.{Field}.{Request}.vtl`  and `{Type}.{Field}.{Resonse}.vtl`, This will make the serverless file smaller.

# Example
These fields in `serverless.yml`:

```
- field: getSomeData
   dataSource: myDatasource
   type: Query

- field: putSomeData
   dataSource: myDatasource
   type: Mutation

- field: getOtherData
   dataSource: myDatasource
   type: Query

```

Will map by default to:

```
Query.getSomeData.request.vtl
Query.getSomeData.response.vtl

Mutation.putSomeData.request.vtl
Mutation.outSomeData.response.vtl

Query.getOtherData.request.vtl
Query.getOtherData.response.vtl
```