### PR TITLE
Simplify lambda datasource config

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ custom:
         name: # data source name
         description: 'Lambda DataSource'
         config:
+          functionName: graphql # The function name in your serverless.yml. Ignored if lambdaFunctionArn is provided.
           lambdaFunctionArn: { Fn::GetAtt: [GraphqlLambdaFunction, Arn] } # Where GraphqlLambdaFunction is the lambda function cloudformation resource created by serverless for the serverless function named graphql
           serviceRoleArn: { Fn::GetAtt: [AppSyncLambdaServiceRole, Arn] } # Where AppSyncLambdaServiceRole is an IAM role defined in Resources
           iamRoleStatements: # custom IAM Role statements for this DataSource. Ignored if `serviceRoleArn` is present. Auto-generated if both `serviceRoleArn` and `iamRoleStatements` are omitted

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -98,8 +98,9 @@ custom:
       - type: AWS_LAMBDA
         name: Lambda_MeInfo
         description: 'Lambda DataSource'
-        config:
-          lambdaFunctionArn: { Fn::GetAtt: [GraphqlLambdaFunction, Arn] }
+        config: # Either of functionName or lambdaFunctionArn must tbe provided. When both are present, lambdaFunctionArn is used.
+          functionName: graphql
+          lambdaFunctionArn: { Fn::GetAtt: [GraphqlLambdaFunction, Arn] } #
           serviceRoleArn: { Fn::GetAtt: [AppSyncLambdaServiceRole, Arn] }
 
 

--- a/index.test.js
+++ b/index.test.js
@@ -1,5 +1,6 @@
 const Serverless = require('serverless/lib/Serverless');
 const ServerlessAppsyncPlugin = require('.');
+const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider.js');
 
 let serverless;
 let plugin;
@@ -7,6 +8,11 @@ let config;
 
 beforeEach(() => {
   serverless = new Serverless();
+  const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+  serverless.setProvider('aws', new AwsProvider(serverless, options));
   plugin = new  ServerlessAppsyncPlugin(serverless, {});
   config = {
     name: 'api',
@@ -96,6 +102,97 @@ describe("appsync config", () => {
     );
     const role = plugin.getCloudWatchLogsRole(config);
     expect(role).toEqual({});
+  });
+  
+  test("Datasource generates lambdaFunctionArn from functionName", () => {
+    
+    Object.assign(
+      config,
+      {
+        dataSources: [
+          {
+            type: 'AWS_LAMBDA',
+            name: 'lambdaSource',
+            description: 'lambdaSource Desc',
+            config: {
+              functionName: "myFunc",
+              serviceRoleArn: "arn:aws:iam::123456789012:role/service-role/myLambdaRole",
+            }
+          },
+        ],
+      },
+    );
+    
+    const dataSources = plugin.getDataSourceResources(config);
+    expect(dataSources).toEqual({
+      "GraphQlDslambdaSource":
+        {
+          "Type": "AWS::AppSync::DataSource",
+          "Properties": {
+            Type: 'AWS_LAMBDA',
+            "ApiId": {
+              "Fn::GetAtt": [
+                "GraphQlApi",
+                "ApiId",
+              ],
+            },
+            Name: 'lambdaSource',
+            ServiceRoleArn: "arn:aws:iam::123456789012:role/service-role/myLambdaRole",
+            Description: 'lambdaSource Desc',
+            LambdaConfig: {
+              LambdaFunctionArn: {
+                "Fn::GetAtt": ["MyFuncLambdaFunction", "Arn"]
+              },
+            }
+          },
+        },
+    });
+  });
+  
+  test("Datasource uses lambdaFunctionArn when provided", () => {
+    
+    Object.assign(
+      config,
+      {
+        dataSources: [
+          {
+            type: 'AWS_LAMBDA',
+            name: 'lambdaSource',
+            description: 'lambdaSource Desc',
+            config: {
+              functionName: "myDummyFunc",
+              lambdaFunctionArn: {"Fn::GetAtt": ["MyFuncLambdaFunction", "Arn"]},
+              serviceRoleArn: "arn:aws:iam::123456789012:role/service-role/myLambdaRole",
+            }
+          },
+        ],
+      },
+    );
+    
+    const dataSources = plugin.getDataSourceResources(config);
+    expect(dataSources).toEqual({
+      "GraphQlDslambdaSource":
+        {
+          "Type": "AWS::AppSync::DataSource",
+          "Properties": {
+            Type: 'AWS_LAMBDA',
+            "ApiId": {
+              "Fn::GetAtt": [
+                "GraphQlApi",
+                "ApiId",
+              ],
+            },
+            Name: 'lambdaSource',
+            ServiceRoleArn: "arn:aws:iam::123456789012:role/service-role/myLambdaRole",
+            Description: 'lambdaSource Desc',
+            LambdaConfig: {
+              LambdaFunctionArn: {
+                "Fn::GetAtt": ["MyFuncLambdaFunction", "Arn"]
+              },
+            }
+          },
+        },
+    });
   });
 
 });
@@ -579,5 +676,5 @@ describe("iamRoleStatements", () => {
     const roles = plugin.getDataSourceIamRolesResouces(config);
     expect(roles).toEqual({});
   });
-  
+
 });


### PR DESCRIPTION
Basically, this will simplify lambda datasources and allow you to do

````yml
- type: AWS_LAMBDA
    name: myLambdaDatasource
    description: 'My Lambda Datasource'
    config:
      functionName: myLambda
````

Where `myLambda` is the key name of your lambda in your `serverless.yml`

instead of 

````yml
- type: AWS_LAMBDA
    name: myLambdaDatasource
    description: 'My Lambda Datasource'
    config:
      lambdaFunctionArn: { Fn::GetAtt: [MyLambdaLambdaFunction, Arn] }
````

This will also work with [AppSync Emulator](https://github.com/ConduitVC/aws-utils/tree/appsync/packages/appsync-emulator-serverless), and will prevent you from having to do this:

````yml
- type: AWS_LAMBDA
    name: myLambdaDatasource
    description: 'My Lambda Datasource'
    config:
      functionName: myLambda
      lambdaFunctionArn: { Fn::GetAtt: [MyLambdaLambdaFunction, Arn] }
````
