### PR TITLE
Feature/support datasource arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ custom:
         description: 'Http endpoint'
         config:
           endpoint: # required # "https://{DOMAIN}/{PATH}"
+      - ${file({dataSources}.yml)} # link to a file with an array or object of datasources
     substitutions: # allows to pass variables from here to velocity templates
       # ${exampleVar1} will be replaced with given value in all mapping templates
       exampleVar1: "${self:service.name}"

--- a/__snapshots__/get-config.test.js.snap
+++ b/__snapshots__/get-config.test.js.snap
@@ -4,6 +4,260 @@ exports[`authenticationType is missing 1`] = `"appSync property \`authentication
 
 exports[`authenticationType is missing 2`] = `"appSync property \`authenticationType\` is missing or invalid."`;
 
+exports[`datasources as array 1`] = `
+Object {
+  "apiId": undefined,
+  "apiKey": undefined,
+  "authenticationType": "AWS_IAM",
+  "dataSources": Array [
+    Object {
+      "name": "users",
+      "type": "AMAZON_DYNAMODB",
+    },
+    Object {
+      "name": "tweets",
+      "type": "AMAZON_DYNAMODB",
+    },
+  ],
+  "functionConfigurations": Array [],
+  "functionConfigurationsLocation": "function-configurations",
+  "isSingleConfig": true,
+  "logConfig": undefined,
+  "mappingTemplates": Array [],
+  "mappingTemplatesLocation": "mapping-templates",
+  "name": "api",
+  "openIdConnectConfig": undefined,
+  "region": "us-east-1",
+  "schema": "type Mutation {
+	# Create a tweet for a user
+	# consumer keys and tokens are not required for dynamo integration
+	createTweet(
+		tweet: String!,
+		consumer_key: String,
+		consumer_secret: String,
+		access_token_key: String,
+		access_token_secret: String,
+		created_at: String!
+	): Tweet!
+
+	# Delete User Tweet
+	deleteTweet(
+	    tweet_id: String!,
+	    consumer_key: String,
+        consumer_secret: String,
+        access_token_key: String,
+        access_token_secret: String
+    ): Tweet!
+
+	# Retweet existing Tweet
+	reTweet(
+	    tweet_id: String!,
+	    consumer_key: String,
+        consumer_secret: String,
+        access_token_key: String,
+        access_token_secret: String
+    ): Tweet!
+
+	# Update existing Tweet
+	updateTweet(tweet_id: String!, tweet: String!): Tweet!
+
+    # Create user info is available in dynamo integration
+	updateUserInfo(
+		location: String!,
+		description: String!,
+		name: String!,
+		followers_count: Int!,
+		friends_count: Int!,
+		favourites_count: Int!,
+		followers: [String!]!
+	): User!
+}
+
+type Query {
+	meInfo(consumer_key: String, consumer_secret: String): User!
+	getUserInfo(handle: String!, consumer_key: String, consumer_secret: String): User!
+
+	# search functionality is available in elasticsearch integration
+	searchAllTweetsByKeyword(keyword: String!): TweetConnection
+}
+
+type Subscription {
+	addTweet: Tweet
+		@aws_subscribe(mutations: [\\"createTweet\\"])
+}
+
+type Tweet {
+	tweet_id: String!
+	tweet: String!
+	retweeted: Boolean
+	retweet_count: Int
+	favorited: Boolean
+	created_at: String!
+}
+
+type TweetConnection {
+	items: [Tweet!]!
+	nextToken: String
+}
+
+type User {
+	name: String!
+	handle: String!
+	location: String!
+	description: String!
+	followers_count: Int!
+	friends_count: Int!
+	favourites_count: Int!
+	followers: [String!]!
+	topTweet: Tweet
+	tweets(limit: Int!, nextToken: String): TweetConnection
+
+	# search functionality is available in elasticsearch integration
+    searchTweetsByKeyword(keyword: String!): TweetConnection
+}
+
+schema {
+	query: Query
+	mutation: Mutation
+	subscription: Subscription
+}
+",
+  "substitutions": Object {},
+  "userPoolConfig": undefined,
+}
+`;
+
+exports[`datasources as array form different files (array of arrays or objects) 1`] = `
+Object {
+  "apiId": undefined,
+  "apiKey": undefined,
+  "authenticationType": "AWS_IAM",
+  "dataSources": Array [
+    Object {
+      "name": "users",
+      "type": "AMAZON_DYNAMODB",
+    },
+    Object {
+      "name": "tweets",
+      "type": "AMAZON_DYNAMODB",
+    },
+    Object {
+      "name": "foo",
+      "type": "AMAZON_DYNAMODB",
+    },
+    Object {
+      "name": "bar",
+      "type": "AMAZON_DYNAMODB",
+    },
+  ],
+  "functionConfigurations": Array [],
+  "functionConfigurationsLocation": "function-configurations",
+  "isSingleConfig": true,
+  "logConfig": undefined,
+  "mappingTemplates": Array [],
+  "mappingTemplatesLocation": "mapping-templates",
+  "name": "api",
+  "openIdConnectConfig": undefined,
+  "region": "us-east-1",
+  "schema": "type Mutation {
+	# Create a tweet for a user
+	# consumer keys and tokens are not required for dynamo integration
+	createTweet(
+		tweet: String!,
+		consumer_key: String,
+		consumer_secret: String,
+		access_token_key: String,
+		access_token_secret: String,
+		created_at: String!
+	): Tweet!
+
+	# Delete User Tweet
+	deleteTweet(
+	    tweet_id: String!,
+	    consumer_key: String,
+        consumer_secret: String,
+        access_token_key: String,
+        access_token_secret: String
+    ): Tweet!
+
+	# Retweet existing Tweet
+	reTweet(
+	    tweet_id: String!,
+	    consumer_key: String,
+        consumer_secret: String,
+        access_token_key: String,
+        access_token_secret: String
+    ): Tweet!
+
+	# Update existing Tweet
+	updateTweet(tweet_id: String!, tweet: String!): Tweet!
+
+    # Create user info is available in dynamo integration
+	updateUserInfo(
+		location: String!,
+		description: String!,
+		name: String!,
+		followers_count: Int!,
+		friends_count: Int!,
+		favourites_count: Int!,
+		followers: [String!]!
+	): User!
+}
+
+type Query {
+	meInfo(consumer_key: String, consumer_secret: String): User!
+	getUserInfo(handle: String!, consumer_key: String, consumer_secret: String): User!
+
+	# search functionality is available in elasticsearch integration
+	searchAllTweetsByKeyword(keyword: String!): TweetConnection
+}
+
+type Subscription {
+	addTweet: Tweet
+		@aws_subscribe(mutations: [\\"createTweet\\"])
+}
+
+type Tweet {
+	tweet_id: String!
+	tweet: String!
+	retweeted: Boolean
+	retweet_count: Int
+	favorited: Boolean
+	created_at: String!
+}
+
+type TweetConnection {
+	items: [Tweet!]!
+	nextToken: String
+}
+
+type User {
+	name: String!
+	handle: String!
+	location: String!
+	description: String!
+	followers_count: Int!
+	friends_count: Int!
+	favourites_count: Int!
+	followers: [String!]!
+	topTweet: Tweet
+	tweets(limit: Int!, nextToken: String): TweetConnection
+
+	# search functionality is available in elasticsearch integration
+    searchTweetsByKeyword(keyword: String!): TweetConnection
+}
+
+schema {
+	query: Query
+	mutation: Mutation
+	subscription: Subscription
+}
+",
+  "substitutions": Object {},
+  "userPoolConfig": undefined,
+}
+`;
+
 exports[`returns valid config 1`] = `
 Object {
   "apiId": undefined,

--- a/get-config.js
+++ b/get-config.js
@@ -47,8 +47,23 @@ const getConfig = (config, provider, servicePath) => {
   const schemaContent = fs.readFileSync(schemaPath, {
     encoding: 'utf8',
   });
-
-  const dataSources = objectToArrayWithNameProp(config.dataSources);
+  
+  let dataSources = [];
+  if (Array.isArray(config.dataSources)) {
+    dataSources = config.dataSources.reduce(
+      (acc, value) => {
+        // Do not call `objectToArrayWithNameProp` on datasources objects``
+        if (value.name !== undefined && typeof value.name === 'string') {
+          return acc.concat(value);
+        } else {
+          return acc.concat(objectToArrayWithNameProp(value));
+        }
+      },
+      []
+    );
+  } else {
+    dataSources = objectToArrayWithNameProp(config.dataSources);
+  }
 
   return {
     name: config.name || 'api',

--- a/get-config.test.js
+++ b/get-config.test.js
@@ -36,3 +36,54 @@ test('returns valid config', () => {
     servicePath,
   )[0]).toMatchSnapshot();
 });
+
+test('datasources as array', () => {
+  expect(getConfig(
+    {
+      authenticationType: 'AWS_IAM',
+      dataSources: [
+        {
+          name: 'users',
+          type: 'AMAZON_DYNAMODB',
+        },
+        {
+          name: 'tweets',
+          type: 'AMAZON_DYNAMODB',
+        },
+      ],
+    },
+    { region: 'us-east-1' },
+    servicePath
+  )[0]).toMatchSnapshot();
+});
+
+test('datasources as array form different files (array of arrays or objects)', () => {
+
+  expect(getConfig(
+    {
+      authenticationType: 'AWS_IAM',
+      dataSources: [ // File one: key-based datasources
+        {
+          users: {
+            type: 'AMAZON_DYNAMODB',
+          },
+          tweets: {
+            type: 'AMAZON_DYNAMODB',
+          },
+        },
+        [ // file 2: array of datasources
+          {
+            name: 'foo',
+            type: 'AMAZON_DYNAMODB',
+          },
+          {
+            name: 'bar',
+            type: 'AMAZON_DYNAMODB',
+          },
+        ]
+      ],
+    },
+    { region: 'us-east-1' },
+    servicePath
+  )[0]).toMatchSnapshot();
+});


### PR DESCRIPTION
Just as mapping templates in multiple files are supported, dataSources are now supported as well.

In each file, the following will work:

As an Object whose keys are the datasource names:

````yml
# file1.yml
dataSourceName:
  type: AWS_LAMBDA
  config:
    functionName: myFunction
````

As an Array, specifying `name`
````yml
# file2.ylm
- type: AWS_LAMBDA
  name: dataSourceName2
  config:
    functionName: myFunction2
````


````yml
datasources:
 - ${file(file1.yml)}
 - ${file(file2.yml)}
````

Passing an array or object directly will keep working as well:

````yml
datasources:
  - type: AWS_LAMBDA
    name: dataSourceName
    config:
      functionName: myFunction
````

````yml
datasources:
  dataSourceName2:
    type: AWS_LAMBDA
    name: dataSourceName2
    config:
      functionName: myFunction2
````