### PR TITLE
Added automatic CloudWatch LogGroup creation & deletion with expiry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "6.10"
-  - "8.10"
+  - "8"
+  - "10"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Tired of 🚀 **deploying**, ✏️ **updating**, and ❌ **deleting** your AppS
  <summary><strong>Table of Contents</strong> (click to expand)</summary>
 
 * [Getting Started](#-getting-started)
+* [Minimum requirements](#-minimum-requirements)
 * [Installation](#-installation)
 * [Usage](#️-usage)
 * [Notes](#-notes)
@@ -42,6 +43,11 @@ Be sure to check out all that <a href="https://aws.amazon.com/appsync" target="_
 * <a target="_blank" href="https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference.html">Mapping Templates</a> - Not sure how to create Mapping Templates for **DynamoDB**, **Lambda** or **Elasticsearch**? Here's a great place to start!
 * <a target="_blank" href="https://docs.aws.amazon.com/appsync/latest/devguide/tutorials.html">Data Sources and Resolvers</a> - Get more information on what data sources are supported and how to set them up!
 * <a target="_blank" href="https://docs.aws.amazon.com/appsync/latest/devguide/security.html">Security</a> - Checkout this guide to find out more information on securing your API endpoints with AWS_IAM or Cognito User Pools!
+
+## 🛠 Minimum requirements
+
+* [Node.js v8 or higher](https://nodejs.org)
+* [Serverless v1.30.0 or higher](https://github.com/serverless/serverless)
 
 ## 💾 Installation
 

--- a/index.js
+++ b/index.js
@@ -310,7 +310,7 @@ class ServerlessAppsyncPlugin {
             LogGroupName: { 'Fn::Join': ['/', ['/aws/appsync/apis', { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] }]] },
             RetentionInDays: this.serverless.service.provider.logRetentionInDays,
           },
-        }
+        },
       },
     };
   }

--- a/index.js
+++ b/index.js
@@ -303,6 +303,15 @@ class ServerlessAppsyncPlugin {
           },
         },
       },
+      ...config.logConfig && config.logConfig.level && {
+        [`${logicalIdGraphQLApi}LogGroup`]: {
+          Type: 'AWS::Logs::LogGroup',
+          Properties: {
+            LogGroupName: { 'Fn::Join': ['/', ['/aws/appsync/apis', { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] }]] },
+            RetentionInDays: this.serverless.service.provider.logRetentionInDays,
+          },
+        }
+      },
     };
   }
 

--- a/index.test.js
+++ b/index.test.js
@@ -104,12 +104,12 @@ describe("appsync config", () => {
     expect(role).toEqual({});
   });
   
-  test("appsync cloudwatch log group is not created when are not logs enabled", () => {
+  test('appsync cloudwatch log group is not created when are not logs enabled', () => {
     const resources = plugin.getGraphQlApiEndpointResource(config);
-    expect(resources['GraphQlApiLogGroup']).toBeUndefined();
+    expect(resources.GraphQlApiLogGroup).toBeUndefined();
   });
 
-  test("appsync cloudwatch log group is created when logs enabled", () => {
+  test('appsync cloudwatch log group is created when logs enabled', () => {
     serverless.service.provider.logRetentionInDays = 14;
     const resources = plugin.getGraphQlApiEndpointResource({
       ...config,
@@ -118,16 +118,16 @@ describe("appsync config", () => {
       },
     });
 
-    expect(resources['GraphQlApiLogGroup']).toEqual({
+    expect(resources.GraphQlApiLogGroup).toEqual({
       Properties: {
         LogGroupName: {
-          "Fn::Join": ["/", ["/aws/appsync/apis", {
-            "Fn::GetAtt": ["GraphQlApi", "ApiId"]
-          }]]
+          'Fn::Join': ['/', ['/aws/appsync/apis', {
+            'Fn::GetAtt': ['GraphQlApi', 'ApiId'],
+          }]],
         },
-        RetentionInDays: 14
+        RetentionInDays: 14,
       },
-      Type: "AWS::Logs::LogGroup"
+      Type: 'AWS::Logs::LogGroup',
     });
   });
   

--- a/index.test.js
+++ b/index.test.js
@@ -104,6 +104,33 @@ describe("appsync config", () => {
     expect(role).toEqual({});
   });
   
+  test("appsync cloudwatch log group is not created when are not logs enabled", () => {
+    const resources = plugin.getGraphQlApiEndpointResource(config);
+    expect(resources['GraphQlApiLogGroup']).toBeUndefined();
+  });
+
+  test("appsync cloudwatch log group is created when logs enabled", () => {
+    serverless.service.provider.logRetentionInDays = 14;
+    const resources = plugin.getGraphQlApiEndpointResource({
+      ...config,
+      logConfig: {
+        level: 'ALL',
+      },
+    });
+
+    expect(resources['GraphQlApiLogGroup']).toEqual({
+      Properties: {
+        LogGroupName: {
+          "Fn::Join": ["/", ["/aws/appsync/apis", {
+            "Fn::GetAtt": ["GraphQlApi", "ApiId"]
+          }]]
+        },
+        RetentionInDays: 14
+      },
+      Type: "AWS::Logs::LogGroup"
+    });
+  });
+  
   test("Datasource generates lambdaFunctionArn from functionName", () => {
     
     Object.assign(


### PR DESCRIPTION
Currently if you enable logging an AWS role is created with permissions to create a new log group, but because this log group has not been created by serverless as part of the CloudFormation it is not cleaned up/deleted when removing the project.

This will automatically add a log group for AppSync if a `logConfig.level` has been set and also set a log expiry based on [`logRetentionInDays`](https://serverless.com/framework/docs/providers/aws/guide/serverless.yml/) (if set).