### PR TITLE
Add multiple authorization types support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,21 @@ custom:
       clientId:
       iatTTL:
       authTTL:
+    # Array of additional authentication providers
+    additionalAuthenticationProviders:
+      - authenticationType: API_KEY
+      - authenticationType: AWS_IAM
+      - authenticationType: OPENID_CONNECT
+        openIdConnectConfig:
+          issuer:
+          clientId:
+          iatTTL:
+          authTTL:
+      - authenticationType: AMAZON_COGNITO_USER_POOLS
+        userPoolConfig:
+          awsRegion: # defaults to provider region
+          userPoolId: # required # user pool ID
+          appIdClientRegex: # optional
     logConfig:
       loggingRoleArn: { Fn::GetAtt: [AppSyncLoggingServiceRole, Arn] } # Where AppSyncLoggingServiceRole is a role with CloudWatch Logs write access
       level: ERROR # Logging Level: NONE | ERROR | ALL

--- a/__snapshots__/get-config.test.js.snap
+++ b/__snapshots__/get-config.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Schema as array 1`] = `
 Object {
+  "additionalAuthenticationProviders": Array [],
   "apiId": undefined,
   "apiKey": undefined,
   "authenticationType": "AWS_IAM",
@@ -82,6 +83,7 @@ type User {
 
 exports[`Schema as string 1`] = `
 Object {
+  "additionalAuthenticationProviders": Array [],
   "apiId": undefined,
   "apiKey": undefined,
   "authenticationType": "AWS_IAM",
@@ -200,6 +202,7 @@ exports[`authenticationType is missing 2`] = `"appSync property \`authentication
 
 exports[`datasources as array 1`] = `
 Object {
+  "additionalAuthenticationProviders": Array [],
   "apiId": undefined,
   "apiKey": undefined,
   "authenticationType": "AWS_IAM",
@@ -323,6 +326,7 @@ schema {
 
 exports[`datasources as array form different files (array of arrays or objects) 1`] = `
 Object {
+  "additionalAuthenticationProviders": Array [],
   "apiId": undefined,
   "apiKey": undefined,
   "authenticationType": "AWS_IAM",
@@ -454,6 +458,7 @@ schema {
 
 exports[`returns valid config 1`] = `
 Object {
+  "additionalAuthenticationProviders": Array [],
   "apiId": undefined,
   "apiKey": undefined,
   "authenticationType": "AWS_IAM",

--- a/get-config.js
+++ b/get-config.js
@@ -71,6 +71,7 @@ const getConfig = (config, provider, servicePath) => {
     apiKey: config.apiKey,
     region: provider.region,
     authenticationType: config.authenticationType,
+    additionalAuthenticationProviders: config.additionalAuthenticationProviders || [],
     schema: schemaContent,
     userPoolConfig: config.userPoolConfig,
     openIdConnectConfig: config.openIdConnectConfig,

--- a/index.js
+++ b/index.js
@@ -290,6 +290,42 @@ class ServerlessAppsyncPlugin {
     });
   }
 
+  getUserPoolConfig(provider, region) {
+    const userPoolConfig = {
+      AwsRegion: provider.userPoolConfig.awsRegion || region,
+      UserPoolId: provider.userPoolConfig.userPoolId,
+      AppIdClientRegex: provider.userPoolConfig.appIdClientRegex,
+    };
+
+    if (provider.userPoolConfig.defaultAction) {
+      Object.assign(userPoolConfig, { DefaultAction: provider.userPoolConfig.defaultAction });
+    }
+
+    return userPoolConfig;
+  }
+
+  getOpenIDConnectConfig(provider) {
+    const openIdConnectConfig = {
+      Issuer: provider.openIdConnectConfig.issuer,
+      ClientId: provider.openIdConnectConfig.clientId,
+      IatTTL: provider.openIdConnectConfig.iatTTL,
+      AuthTTL: provider.openIdConnectConfig.authTTL,
+    };
+
+    return openIdConnectConfig;
+  }
+
+  mapAuthenticationProvider(provider, region) {
+    const authenticationType = provider.authenticationType;
+    const Provider = {
+      AuthenticationType: authenticationType,
+      UserPoolConfig: authenticationType !== 'AMAZON_COGNITO_USER_POOLS' ? undefined : this.getUserPoolConfig(provider, region),
+      OpenIDConnectConfig: authenticationType !== 'OPENID_CONNECT' ? undefined : this.getOpenIDConnectConfig(provider),
+    };
+
+    return Provider;
+  }
+
   getGraphQlApiEndpointResource(config) {
     const logicalIdGraphQLApi = this.getLogicalId(config, RESOURCE_API);
     const logicalIdCloudWatchLogsRole = this.getLogicalId(config, RESOURCE_API_CLOUDWATCH_LOGS_ROLE);
@@ -308,18 +344,9 @@ class ServerlessAppsyncPlugin {
         Properties: {
           Name: config.name,
           AuthenticationType: config.authenticationType,
-          UserPoolConfig: config.authenticationType !== 'AMAZON_COGNITO_USER_POOLS' ? undefined : {
-            AwsRegion: config.userPoolConfig.awsRegion || config.region,
-            DefaultAction: config.userPoolConfig.defaultAction,
-            UserPoolId: config.userPoolConfig.userPoolId,
-            AppIdClientRegex: config.userPoolConfig.appIdClientRegex,
-          },
-          OpenIDConnectConfig: config.authenticationType !== 'OPENID_CONNECT' ? undefined : {
-            Issuer: config.openIdConnectConfig.issuer,
-            ClientId: config.openIdConnectConfig.clientId,
-            IatTTL: config.openIdConnectConfig.iatTTL,
-            AuthTTL: config.openIdConnectConfig.authTTL,
-          },
+          AdditionalAuthenticationProviders: config.additionalAuthenticationProviders.map(provider => this.mapAuthenticationProvider(provider, config.region)),
+          UserPoolConfig: config.authenticationType !== 'AMAZON_COGNITO_USER_POOLS' ? undefined : this.getUserPoolConfig(config, config.region),
+          OpenIDConnectConfig: config.authenticationType !== 'OPENID_CONNECT' ? undefined : this.getOpenIDConnectConfig(config),
           LogConfig: !config.logConfig ? undefined : {
             CloudWatchLogsRoleArn:
               config.logConfig.loggingRoleArn ||


### PR DESCRIPTION
Fixes #241

Since the CloudFormation docs are lacking:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-graphqlapi.html

I used the cli as a reference and followed the same naming conventions:
https://docs.aws.amazon.com/cli/latest/reference/appsync/create-graphql-api.html

example:
```
appSync:
    name:
    authenticationType: AMAZON_COGNITO_USER_POOLS
    additionalAuthenticationProviders:
      - authenticationType: AWS_IAM
      - authenticationType: OPENID_CONNECT
        openIdConnectConfig:
          issuer:
          clientId:
          iatTTL:
          authTTL:
```

Still work in progress and I would like some feedback as I don't think I can test all possible scenarios with my setup (I've tested `AMAZON_COGNITO_USER_POOLS` as `authenticationType` and `AWS_IAM` as `additionalAuthenticationProviders`)

I'll update the docs after I get more feedback

Edit:
https://github.com/aws/aws-appsync-community/issues/1#issuecomment-493131312