### PR TITLE
 Substitions with an ImportValue was writing [object object] to vtl 

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ plugins:
 module.exports = {
   'AWS::AppSync::ApiKey': { destination: 'AppSync', allowSuffix: true },
   'AWS::AppSync::DataSource': { destination: 'AppSync', allowSuffix: true },
+  'AWS::AppSync::FunctionConfiguration': { destination: 'AppSync', allowSuffix: true },
   'AWS::AppSync::GraphQLApi': { destination: 'AppSync', allowSuffix: true },
   'AWS::AppSync::GraphQLSchema': { destination: 'AppSync', allowSuffix: true },
   'AWS::AppSync::Resolver': { destination: 'AppSync', allowSuffix: true }

--- a/index.js
+++ b/index.js
@@ -881,8 +881,8 @@ class ServerlessAppsyncPlugin {
     let templateJoin = template.split('|||');
     for (let i = 0; i < templateJoin.length; i++) {
       if (substitutions[templateJoin[i]]) {
-        let subs = '{"' + templateJoin[i] + '": "' + substitutions[templateJoin[i]] + '"}'
-        templateJoin[i] = { 'Fn::Sub': ['${' + templateJoin[i] + '}', JSON.parse(subs)] };
+        let subs = { [ templateJoin[i] ] : substitutions[templateJoin[i]] };
+        templateJoin[i] = { 'Fn::Sub': ['${' + templateJoin[i] + '}', subs] };
       }
     }
     return { 'Fn::Join': ["", templateJoin] };


### PR DESCRIPTION
This comment ( from #134 https://github.com/sid88in/serverless-appsync-plugin/issues/134#issuecomment-474145287 ) mentions a regression when ImportValue is used in substitutions and writes [object object] to the resulting VTL.

It looks like it was trying to construct a string of a JS object through string concatenation then JSON.parse'ing it in the next line. So i've kept it as an object throughout.

In testing it looks to work on my project where substitutions are either an ImportValue object or a string:
```
substitutions:
      CompanyTableName: { Fn::ImportValue: "CompanyTable-local" }
      MasterId: "secretonetwothree"
```


(I've also included the FunctionConfiguration item to the split-stacks documentation as recommended in #243)