### PR TITLE
Add option to conceal API keys from output

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ custom:
 
 This command will deploy all AppSync resources in the same CloudFormation template used by the other serverless resources.
 
+* Providing the `--conceal` option will conceal the API keys from the output when the authentication type of `API_KEY` is used.
+
 ### `serverless graphql-playground`
 
 This command will start a local graphql-playground server which is connected to your AppSync endpoint. The required options for the command are different depending on your AppSync authenticationType.

--- a/index.js
+++ b/index.js
@@ -166,10 +166,16 @@ class ServerlessAppsyncPlugin {
   }
 
   displayApiKeys() {
+    const conceal = this.options.conceal;
+
     let apiKeysMessage = `${chalk.yellow('appsync api keys:')}`;
     if (this.gatheredData.apiKeys && this.gatheredData.apiKeys.length) {
       this.gatheredData.apiKeys.forEach( endpoint => {
-        apiKeysMessage += `\n  ${endpoint}`;
+        if (conceal) {
+          apiKeysMessage += "\n  *** (concealed)";
+        } else {
+          apiKeysMessage += `\n  ${endpoint}`;
+        }
       });
     } else {
       apiKeysMessage += "\n  None";

--- a/index.test.js
+++ b/index.test.js
@@ -1,6 +1,7 @@
 const Serverless = require('serverless/lib/Serverless');
 const ServerlessAppsyncPlugin = require('.');
 const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider.js');
+const chalk = require('chalk');
 
 let serverless;
 let plugin;
@@ -9,7 +10,13 @@ let config;
 jest.spyOn(Date, 'now').mockImplementation(() => 10000);
 
 beforeEach(() => {
+  const cli = {
+    log: jest.fn(),
+    consoleLog: jest.fn(),
+  };
   serverless = new Serverless();
+  serverless.cli = cli;
+
   const options = {
     stage: 'dev',
     region: 'us-east-1',
@@ -23,6 +30,21 @@ beforeEach(() => {
     region: 'us-east-1',
     isSingleConfig: true,
   };
+});
+
+describe("appsync display", () => {
+
+  test('appsync api keys are displayed', () => {
+    plugin.gatheredData.apiKeys.push("dummy-api-key-1");
+    plugin.gatheredData.apiKeys.push("dummy-api-key-2");
+
+    let expectedMessage = '';
+    expectedMessage += `${chalk.yellow('appsync api keys:')}\n`;
+    expectedMessage += '  dummy-api-key-1\n';
+    expectedMessage += '  dummy-api-key-2';
+
+    expect(plugin.displayApiKeys()).toEqual(expectedMessage);
+  });
 });
 
 describe("appsync config", () => {

--- a/index.test.js
+++ b/index.test.js
@@ -34,14 +34,25 @@ beforeEach(() => {
 
 describe("appsync display", () => {
 
-  test('appsync api keys are displayed', () => {
-    plugin.gatheredData.apiKeys.push("dummy-api-key-1");
-    plugin.gatheredData.apiKeys.push("dummy-api-key-2");
+  test("appsync api keys are displayed", () => {
+    plugin.gatheredData.apiKeys = ["dummy-api-key-1", "dummy-api-key-2"];
 
     let expectedMessage = '';
-    expectedMessage += `${chalk.yellow('appsync api keys:')}\n`;
-    expectedMessage += '  dummy-api-key-1\n';
-    expectedMessage += '  dummy-api-key-2';
+    expectedMessage += `${chalk.yellow("appsync api keys:")}`;
+    expectedMessage += '\n  dummy-api-key-1';
+    expectedMessage += '\n  dummy-api-key-2';
+
+    expect(plugin.displayApiKeys()).toEqual(expectedMessage);
+  });
+
+  test("appsync api keys are hidden when `--conceal` is given", () => {
+    plugin.options.conceal = true;
+    plugin.gatheredData.apiKeys = ["dummy-api-key-1", "dummy-api-key-2"];
+
+    let expectedMessage = '';
+    expectedMessage += `${chalk.yellow("appsync api keys:")}`;
+    expectedMessage += '\n  *** (concealed)';
+    expectedMessage += '\n  *** (concealed)';
 
     expect(plugin.displayApiKeys()).toEqual(expectedMessage);
   });


### PR DESCRIPTION
Implements the `--conceal` argument in the same fashion as the [API Gateway to hide API keys from the output](https://github.com/serverless/serverless/pull/4382).

[Real-world example of it in action](https://github.com/SketchingDev/ServerlessRealtimeReporter/runs/314990393#step:5:53)

## Without

```
$ sls deploy
...
appsync api keys:
  da2-tjmux5pd4bg28erxnswub4opd4
endpoints:
  None
appsync endpoints:
  https://bbjffpadibkrgvg6mm5qeoxzhy.appsync-api.us-east-1.amazonaws.com/graphql
```

## With

```
$ sls deploy --conceal
...
appsync api keys:
  *** (concealed)
endpoints:
  None
appsync endpoints:
  https://bbjffpadjffrnmg6mp1keoxgay.appsync-api.us-east-1.amazonaws.com/graphql
```