### PR TITLE
Improved pipeline handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ custom:
         # kind: UNIT (default, not required) or PIPELINE (required for pipeline resolvers)
         functions: # array of functions if kind === 'PIPELINE'
           - # function name
-        request: # request mapping template name | defaults to {field}.{type}.{pipeline ? before : request}.vtl
-        response: # response mapping template name | defaults to {field}.{type}.{pipeline ? after : response}.vtl
+        request: # request mapping template name | defaults to {type}.{field}.request.vtl
+        response: # response mapping template name | defaults to {type}.{field}.response.vtl
         # When caching is enaled with `PER_RESOLVER_CACHING`,
         # the caching options of the resolver.
         # Disabled by default.
@@ -284,8 +284,8 @@ custom:
     mappingTemplates:
       - type: Query
         field: testPipelineQuery
-        request: './mapping-templates/before.vtl' # the pipeline's "before" mapping template
-        response: './mapping-templates/after.vtl' # the pipeline's "after" mapping template
+        request: './mapping-templates/before.vtl' # the pipeline's "before" mapping template, defaults to {type}.{field).request.vtl
+        response: './mapping-templates/after.vtl' # the pipeline's "after" mapping template, defaults to {type}.{field}.response.vtl
         kind: PIPELINE
         functions:
           - authorizeFunction
@@ -293,12 +293,12 @@ custom:
     functionConfigurations:
       - dataSource: graphqlLambda
         name: 'authorizeFunction'
-        request: './mapping-templates/authorize-request.vtl'
-        response: './mapping-templates/common-response.vtl'
+        request: './mapping-templates/authorize-request.vtl' # defaults to {name}.request.vtl
+        response: './mapping-templates/common-response.vtl' # defaults to {name}.response.vtl
       - dataSource: dataTable
         name: 'fetchDataFunction'
-        request: './mapping-templates/fetchData.vtl'
-        response: './mapping-templates/common-response.vtl'
+        request: './mapping-templates/fetchData.vtl' # defaults to {name}.request.vtl
+        response: './mapping-templates/common-response.vtl' # defaults to {name}.response.vtl
 ```
 
 ## ▶️ Usage

--- a/README.md
+++ b/README.md
@@ -125,8 +125,7 @@ custom:
       - dataSource: # data source name
         type: # type name in schema (e.g. Query, Mutation, Subscription)
         field: getUserInfo
-        # pipeline resolvers use kind: PIPELINE, otherwise kind is not required
-        # kind: pipeline
+        # kind: UNIT (default, not required) or PIPELINE (required for pipeline resolvers)
         functions: # array of functions if kind === 'PIPELINE'
           - # function name
         request: # request mapping template name | defaults to {field}.{type}.{pipeline ? before : request}.vtl

--- a/README.md
+++ b/README.md
@@ -123,10 +123,12 @@ custom:
     mappingTemplatesLocation: # defaults to mapping-templates
     mappingTemplates:
       - dataSource: # data source name
-        type: # type name in schema (e.g. Query, Mutation, Subscription)
+        type: # type name in schema (e.g. Query, Mutation, Subscription, PIPELINE)
         field: getUserInfo
-        request: # request mapping template name
-        response: # response mapping template name
+        functions: # array of functions if type === 'PIPELINE'
+          - # function name
+        request: # request mapping template name | defaults to {field}.{type}.{pipeline ? before : request}.vtl
+        response: # response mapping template name | defaults to {field}.{type}.{pipeline ? after : response}.vtl
         # When caching is enaled with `PER_RESOLVER_CACHING`,
         # the caching options of the resolver.
         # Disabled by default.
@@ -143,6 +145,11 @@ custom:
           ttl: 1000 # override the ttl for this resolver. (default comes from global config)
 
       - ${file({fileLocation}.yml)} # link to a file with arrays of mapping templates
+    functionConfigurations:
+      - name: # function name
+        dataSource: # data source name
+        request: # request mapping template name | defaults to {name}.request.vtl
+        response: # reponse mapping template name | defaults to {name}.response.vtl
     dataSources:
       - type: AMAZON_DYNAMODB
         name: # data source name

--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ custom:
     mappingTemplatesLocation: # defaults to mapping-templates
     mappingTemplates:
       - dataSource: # data source name
-        type: # type name in schema (e.g. Query, Mutation, Subscription, PIPELINE)
+        type: # type name in schema (e.g. Query, Mutation, Subscription)
         field: getUserInfo
-        functions: # array of functions if type === 'PIPELINE'
+        # pipeline resolvers use kind: PIPELINE, otherwise kind is not required
+        # kind: pipeline
+        functions: # array of functions if kind === 'PIPELINE'
           - # function name
         request: # request mapping template name | defaults to {field}.{type}.{pipeline ? before : request}.vtl
         response: # response mapping template name | defaults to {field}.{type}.{pipeline ? after : response}.vtl

--- a/src/index.js
+++ b/src/index.js
@@ -872,10 +872,8 @@ class ServerlessAppsyncPlugin {
     const flattenedMappingTemplates = config.mappingTemplates
       .reduce((accumulator, currentValue) => accumulator.concat(currentValue), []);
     return flattenedMappingTemplates.reduce((acc, tpl) => {
-      const reqSuffix = tpl.kind === 'PIPELINE' ? 'before' : 'request';
-      const respSuffix = tpl.kind === 'PIPELINE' ? 'after' : 'response';
-      const reqTemplPath = path.join(config.mappingTemplatesLocation, tpl.request || `${tpl.type}.${tpl.field}.${reqSuffix}.vtl`);
-      const respTemplPath = path.join(config.mappingTemplatesLocation, tpl.response || `${tpl.type}.${tpl.field}.${respSuffix}.vtl`);
+      const reqTemplPath = path.join(config.mappingTemplatesLocation, tpl.request || `${tpl.type}.${tpl.field}.request.vtl`);
+      const respTemplPath = path.join(config.mappingTemplatesLocation, tpl.response || `${tpl.type}.${tpl.field}.response.vtl`);
       const requestTemplate = fs.readFileSync(reqTemplPath, 'utf8');
       const responseTemplate = fs.readFileSync(respTemplPath, 'utf8');
 

--- a/src/index.js
+++ b/src/index.js
@@ -825,11 +825,11 @@ class ServerlessAppsyncPlugin {
     return flattenedFunctionConfigurationResources.reduce((acc, tpl) => {
       const reqTemplPath = path.join(
         functionConfigLocation,
-        tpl.request || `${tpl.type}.${tpl.field}.request.vtl`,
+        tpl.request || `${tpl.name}.request.vtl`,
       );
       const respTemplPath = path.join(
         functionConfigLocation,
-        tpl.response || `${tpl.type}.${tpl.field}.response.vtl`,
+        tpl.response || `${tpl.name}.response.vtl`,
       );
       const requestTemplate = fs.readFileSync(reqTemplPath, 'utf8');
       const responseTemplate = fs.readFileSync(respTemplPath, 'utf8');
@@ -872,8 +872,10 @@ class ServerlessAppsyncPlugin {
     const flattenedMappingTemplates = config.mappingTemplates
       .reduce((accumulator, currentValue) => accumulator.concat(currentValue), []);
     return flattenedMappingTemplates.reduce((acc, tpl) => {
-      const reqTemplPath = path.join(config.mappingTemplatesLocation, tpl.request || `${tpl.type}.${tpl.field}.request.vtl`);
-      const respTemplPath = path.join(config.mappingTemplatesLocation, tpl.response || `${tpl.type}.${tpl.field}.response.vtl`);
+      const reqSuffix = tpl.kind === 'PIPELINE' ? "before" : "request";
+      const respSuffix = tpl.kind === 'PIPELINE' ? "after" : "response";
+      const reqTemplPath = path.join(config.mappingTemplatesLocation, tpl.request || `${tpl.type}.${tpl.field}.{reqSuffix}.vtl`);
+      const respTemplPath = path.join(config.mappingTemplatesLocation, tpl.response || `${tpl.type}.${tpl.field}.{respSuffix}.vtl`);
       const requestTemplate = fs.readFileSync(reqTemplPath, 'utf8');
       const responseTemplate = fs.readFileSync(respTemplPath, 'utf8');
 

--- a/src/index.js
+++ b/src/index.js
@@ -872,10 +872,10 @@ class ServerlessAppsyncPlugin {
     const flattenedMappingTemplates = config.mappingTemplates
       .reduce((accumulator, currentValue) => accumulator.concat(currentValue), []);
     return flattenedMappingTemplates.reduce((acc, tpl) => {
-      const reqSuffix = tpl.kind === 'PIPELINE' ? "before" : "request";
-      const respSuffix = tpl.kind === 'PIPELINE' ? "after" : "response";
-      const reqTemplPath = path.join(config.mappingTemplatesLocation, tpl.request || `${tpl.type}.${tpl.field}.{reqSuffix}.vtl`);
-      const respTemplPath = path.join(config.mappingTemplatesLocation, tpl.response || `${tpl.type}.${tpl.field}.{respSuffix}.vtl`);
+      const reqSuffix = tpl.kind === 'PIPELINE' ? 'before' : 'request';
+      const respSuffix = tpl.kind === 'PIPELINE' ? 'after' : 'response';
+      const reqTemplPath = path.join(config.mappingTemplatesLocation, tpl.request || `${tpl.type}.${tpl.field}.${reqSuffix}.vtl`);
+      const respTemplPath = path.join(config.mappingTemplatesLocation, tpl.response || `${tpl.type}.${tpl.field}.${respSuffix}.vtl`);
       const requestTemplate = fs.readFileSync(reqTemplPath, 'utf8');
       const responseTemplate = fs.readFileSync(respTemplPath, 'utf8');
 


### PR DESCRIPTION
Use name for function configurations rather than type / field
Use before/after for pipeline mapping templates rather than request / response
Improve documentation of pipeline mapping templates and function configurations