### PR TITLE
Fix IAM statement for RDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ custom:
               Action:
                 - "rds-data:DeleteItems"
                 - "rds-data:ExecuteSql"
+                - "rds-data:ExecuteStatement"
                 - "rds-data:GetItems"
                 - "rds-data:InsertItems"
                 - "rds-data:UpdateItems"

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -686,6 +686,7 @@ Object {
                 "Action": Array [
                   "rds-data:DeleteItems",
                   "rds-data:ExecuteSql",
+                  "rds-data:ExecuteStatement",
                   "rds-data:GetItems",
                   "rds-data:InsertItems",
                   "rds-data:UpdateItems",
@@ -959,6 +960,7 @@ Object {
                 "Action": Array [
                   "rds-data:DeleteItems",
                   "rds-data:ExecuteSql",
+                  "rds-data:ExecuteStatement",
                   "rds-data:GetItems",
                   "rds-data:InsertItems",
                   "rds-data:UpdateItems",

--- a/index.test.js
+++ b/index.test.js
@@ -504,6 +504,7 @@ describe('iamRoleStatements', () => {
                   Action: [
                     'rds-data:DeleteItems',
                     'rds-data:ExecuteSql',
+                    'rds-data:ExecuteStatement',
                     'rds-data:GetItems',
                     'rds-data:InsertItems',
                     'rds-data:UpdateItems',

--- a/src/index.js
+++ b/src/index.js
@@ -648,6 +648,7 @@ class ServerlessAppsyncPlugin {
           Action: [
             'rds-data:DeleteItems',
             'rds-data:ExecuteSql',
+            'rds-data:ExecuteStatement',
             'rds-data:GetItems',
             'rds-data:InsertItems',
             'rds-data:UpdateItems',


### PR DESCRIPTION
This PR adds the missing permission `rds-data:ExecuteStatement`.

The AppSync tutorial for RDS recommends the following IAM statements:
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "rds-data:DeleteItems",
                "rds-data:ExecuteSql",
                "rds-data:ExecuteStatement", # Currently missing from this plugin
                "rds-data:GetItems",
                "rds-data:InsertItems",
                "rds-data:UpdateItems"
            ],
            "Resource": [
                "arn:aws:rds:us-east-1:123456789012:cluster:mydbcluster",
                "arn:aws:rds:us-east-1:123456789012:cluster:mydbcluster:*"
            ]
        },
        {
            "Effect": "Allow",
            "Action": [
                "secretsmanager:GetSecretValue"
            ],
            "Resource": [
                "arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret",
                "arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret:*"
            ]
        }
    ]
}
```

Reference: https://docs.aws.amazon.com/appsync/latest/devguide/tutorial-rds-resolvers.html#graphql-schema