### PR TITLE
Updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ custom:
       ...
     - name: public-appsync-endpoint
       schema: AppSync/schema.graphql # or something like AppSync/public/schema.graphql
-      authenticationType: NONE # or API_KEY, you get the idea
+      authenticationType: API_KEY
       serviceRole: PublicAppSyncServiceRole
       dataSources:
       ...


### PR DESCRIPTION
AppSync does not support a value of "NONE" for the authentication type.
Trying to use the value present in the README will result in a validation error: "appSync property `authenticationType` is missing or invalid."