### PR TITLE
Support Versioned and DeltaSyncConfig on DynamoDB DataSources

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,11 +168,12 @@ custom:
                 - "arn:aws:dynamodb:{REGION}:{ACCOUNT_ID}:myTable/*"
           # Versioned DataSource configuration
           versioned: false # (default, not required)
-          # When you enable versioning on a DynamoDB data source, you MUST specify the following fields
+          # When you enable versioning on a DynamoDB data source, you specify the following fields
+          # read more at https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appsync-datasource-deltasyncconfig.html
           # deltaSyncConfig:
-          #   baseTableTTL: 0 # The number of minutes to retain deleted items in the Base table with a "tombstone"
-          #   deltaSyncTableName: { Ref: MyTableDelta } # The name of the table where changes made to items with AWS AppSync mutations are stored
-          #   deltaSyncTableTTL: 1440 # The number of minutes to retain items in the Delta table
+          #   baseTableTTL: 0 # (defalut, not required) # The amount of time (in minutes) items should be kept in the base table when deleted. Set to 0 to delete items in the base table immediately
+          #   deltaSyncTableName: { Ref: MyTableDelta } # required # The Delta Sync table name
+          #   deltaSyncTableTTL: 60 # (defalut, not required) # The amount of time (in minutes) the delta sync table will keep track of changes
 
           region: # Overwrite default region for this data source
       - type: RELATIONAL_DATABASE

--- a/README.md
+++ b/README.md
@@ -166,6 +166,13 @@ custom:
               Resource:
                 - "arn:aws:dynamodb:{REGION}:{ACCOUNT_ID}:myTable"
                 - "arn:aws:dynamodb:{REGION}:{ACCOUNT_ID}:myTable/*"
+          # Versioned DataSource configuration
+          versioned: false # (default, not required)
+          # When you enable versioning on a DynamoDB data source, you MUST specify the following fields
+          # deltaSyncConfig:
+          #   baseTableTTL: 0 # The number of minutes to retain deleted items in the Base table with a "tombstone"
+          #   deltaSyncTableName: { Ref: MyTableDelta } # The name of the table where changes made to items with AWS AppSync mutations are stored
+          #   deltaSyncTableTTL: 1440 # The number of minutes to retain items in the Delta table
 
           region: # Overwrite default region for this data source
       - type: RELATIONAL_DATABASE

--- a/README.md
+++ b/README.md
@@ -171,9 +171,9 @@ custom:
           # When you enable versioning on a DynamoDB data source, you specify the following fields
           # read more at https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appsync-datasource-deltasyncconfig.html
           # deltaSyncConfig:
-          #   baseTableTTL: 0 # (defalut, not required) # The amount of time (in minutes) items should be kept in the base table when deleted. Set to 0 to delete items in the base table immediately
+          #   baseTableTTL: 0 # (default, not required) # The amount of time (in minutes) items should be kept in the base table when deleted. Set to 0 to delete items in the base table immediately
           #   deltaSyncTableName: { Ref: MyTableDelta } # required # The Delta Sync table name
-          #   deltaSyncTableTTL: 60 # (defalut, not required) # The amount of time (in minutes) the delta sync table will keep track of changes
+          #   deltaSyncTableTTL: 60 # (default, not required) # The amount of time (in minutes) the delta sync table will keep track of changes
 
           region: # Overwrite default region for this data source
       - type: RELATIONAL_DATABASE

--- a/src/index.js
+++ b/src/index.js
@@ -140,6 +140,18 @@ class ServerlessAppsyncPlugin {
     };
   }
 
+  getDeltaSyncConfig(config) {
+    if (config && config.deltaSyncConfig) {
+      return {
+        BaseTableTTL: config.deltaSyncConfig.baseTableTTL,
+        DeltaSyncTableName: config.deltaSyncConfig.deltaSyncTableName,
+        DeltaSyncTableTTL: config.deltaSyncConfig.deltaSyncTableTTL,
+      };
+    }
+
+    throw new Error('You must specify `deltaSyncConfig` for Delta Sync configuration.');
+  }
+
   gatherData() {
     const stackName = this.provider.naming.getStackName();
 
@@ -756,7 +768,12 @@ class ServerlessAppsyncPlugin {
           AwsRegion: ds.config.region || config.region,
           TableName: ds.config.tableName,
           UseCallerCredentials: !!ds.config.useCallerCredentials,
+          Versioned: !!ds.config.versioned,
         };
+        if (resource.Properties.DynamoDBConfig.Versioned) {
+          resource.Properties.DynamoDBConfig.DeltaSyncConfig =
+            this.getDeltaSyncConfig(Object.assign({}, ds.config));
+        }
       } else if (ds.type === 'AMAZON_ELASTICSEARCH') {
         resource.Properties.ElasticsearchConfig = {
           AwsRegion: ds.config.region || config.region,

--- a/src/index.js
+++ b/src/index.js
@@ -146,10 +146,10 @@ class ServerlessAppsyncPlugin {
         throw new Error('You must specify `deltaSyncTableName` for Delta Sync configuration.');
       }
       return {
-        BaseTableTTL: !config.deltaSyncConfig.baseTableTTL ?
+        BaseTableTTL: typeof config.deltaSyncConfig.baseTableTTL === 'undefined' ?
           0 : config.deltaSyncConfig.baseTableTTL,
         DeltaSyncTableName: config.deltaSyncConfig.deltaSyncTableName,
-        DeltaSyncTableTTL: !config.deltaSyncConfig.deltaSyncTableTTL ?
+        DeltaSyncTableTTL: typeof config.deltaSyncConfig.deltaSyncTableTTL === 'undefined' ?
           60 : config.deltaSyncConfig.deltaSyncTableTTL,
       };
     }

--- a/src/index.js
+++ b/src/index.js
@@ -142,10 +142,13 @@ class ServerlessAppsyncPlugin {
 
   getDeltaSyncConfig(config) {
     if (config && config.deltaSyncConfig) {
+      if (!config.deltaSyncConfig.deltaSyncTableName) {
+        throw new Error('You must specify `deltaSyncTableName` for Delta Sync configuration.');
+      }
       return {
-        BaseTableTTL: config.deltaSyncConfig.baseTableTTL,
+        BaseTableTTL: !config.deltaSyncConfig.baseTableTTL ? 0 : config.deltaSyncConfig.baseTableTTL,
         DeltaSyncTableName: config.deltaSyncConfig.deltaSyncTableName,
-        DeltaSyncTableTTL: config.deltaSyncConfig.deltaSyncTableTTL,
+        DeltaSyncTableTTL: !config.deltaSyncConfig.deltaSyncTableTTL ? 60 : config.deltaSyncConfig.deltaSyncTableTTL,
       };
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -146,9 +146,11 @@ class ServerlessAppsyncPlugin {
         throw new Error('You must specify `deltaSyncTableName` for Delta Sync configuration.');
       }
       return {
-        BaseTableTTL: !config.deltaSyncConfig.baseTableTTL ? 0 : config.deltaSyncConfig.baseTableTTL,
+        BaseTableTTL: !config.deltaSyncConfig.baseTableTTL ?
+          0 : config.deltaSyncConfig.baseTableTTL,
         DeltaSyncTableName: config.deltaSyncConfig.deltaSyncTableName,
-        DeltaSyncTableTTL: !config.deltaSyncConfig.deltaSyncTableTTL ? 60 : config.deltaSyncConfig.deltaSyncTableTTL,
+        DeltaSyncTableTTL: !config.deltaSyncConfig.deltaSyncTableTTL ?
+          60 : config.deltaSyncConfig.deltaSyncTableTTL,
       };
     }
 


### PR DESCRIPTION
AppSync currently supports versioning on DynamoDB data sources.
So, I added this options and updated the example of `serverless.yml` on README.

fixed https://github.com/sid88in/serverless-appsync-plugin/issues/309

---

Example of CloudFormation template is below.

```yaml
  DynamoDBPostsTableDatasource:
    Type: AWS::AppSync::DataSource
    Properties:
      Type: AMAZON_DYNAMODB
      Name: posts
      ApiId:
        Fn::GetAtt:
        - DeltaSyncApi
        - ApiId
      ServiceRoleArn: !GetAtt AppSyncTutorialAmazonDynamoDBRole.Arn
      DynamoDBConfig:
        TableName:
          Ref: DynamoDBTableDeltaSyncPostsTable
        AwsRegion:
          Ref: AWS::Region
        UseCallerCredentials: FALSE
        Versioned: TRUE
        DeltaSyncConfig:
          DeltaSyncTableName:
            Ref: DynamoDBTableDeltaSyncDeltaTable
          DeltaSyncTableTTL: 60
          BaseTableTTL: 0
```

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sid88in/serverless-appsync-plugin/313)
<!-- Reviewable:end -->
