### PR TITLE
Get ElasticSearch automatic role generation working

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ custom:
         name: # data source name
         description: 'ElasticSearch'
         config:
-          endpoint: # required # "https://{DOMAIN}.{REGION}.es.amazonaws.com"
+          domain: # a reference to a resource of type `AWS::Elasticsearch::Domain`
+          endpoint: # required if `domain` not provided. Ex: "https://{XXX}.{REGION}.es.amazonaws.com"
           serviceRoleArn: { Fn::GetAtt: [AppSyncESServiceRole, Arn] } # Where AppSyncESServiceRole is an IAM role defined in Resources
           iamRoleStatements: # custom IAM Role statements for this DataSource. Ignored if `serviceRoleArn` is present. Auto-generated if both `serviceRoleArn` and `iamRoleStatements` are omitted
             - Effect: "Allow"

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -620,7 +620,9 @@ Object {
                 "Resource": Array [
                   Object {
                     "Fn::GetAtt": Array [
-                      "EsResource",
+                      Object {
+                        "Ref": "ESDomain",
+                      },
                       "Arn",
                     ],
                   },

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -615,6 +615,7 @@ Object {
                   "es:ESHttpHead",
                   "es:ESHttpPost",
                   "es:ESHttpPut",
+                  "es:ESHttpPatch",
                 ],
                 "Effect": "Allow",
                 "Resource": Array [
@@ -674,6 +675,7 @@ Object {
                   "es:ESHttpHead",
                   "es:ESHttpPost",
                   "es:ESHttpPut",
+                  "es:ESHttpPatch",
                 ],
                 "Effect": "Allow",
                 "Resource": Array [

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -619,11 +619,19 @@ Object {
                 "Effect": "Allow",
                 "Resource": Array [
                   Object {
-                    "Fn::GetAtt": Array [
-                      Object {
-                        "Ref": "ESDomain",
-                      },
-                      "Arn",
+                    "Fn::Join": Array [
+                      "/",
+                      Array [
+                        Object {
+                          "Fn::GetAtt": Array [
+                            Object {
+                              "Ref": "ESDomain",
+                            },
+                            "Arn",
+                          ],
+                        },
+                        "*",
+                      ],
                     ],
                   },
                 ],
@@ -680,7 +688,7 @@ Object {
                         Object {
                           "Ref": "AWS::AccountId",
                         },
-                        "domain/search-my-domain-abcdefghijklmnop.us-east-1.es.amazonaws.com",
+                        "domain/search-my-domain-abcdefghijklmnop.us-east-1.es.amazonaws.com/*",
                       ],
                     ],
                   },

--- a/index.test.js
+++ b/index.test.js
@@ -562,11 +562,8 @@ describe('iamRoleStatements', () => {
             description: 'other ES Source',
             config: {
               region: 'us-east-1',
-              endpoint: {
-                'Fn::GetAtt': [
-                  'EsResource',
-                  'DomainName',
-                ],
+              domain: {
+                Ref: 'ESDomain',
               },
               iamRoleStatements: [
                 {
@@ -644,11 +641,8 @@ describe('iamRoleStatements', () => {
             description: 'other ES Source',
             config: {
               region: 'us-east-1',
-              endpoint: {
-                'Fn::GetAtt': [
-                  'EsResource',
-                  'DomainName',
-                ],
+              domain: {
+                Ref: 'ESDomain',
               },
             },
           },

--- a/src/index.js
+++ b/src/index.js
@@ -694,7 +694,7 @@ class ServerlessAppsyncPlugin {
       case 'AMAZON_ELASTICSEARCH': {
         let arn;
         if (ds.config.domain) {
-          arn = { 'Fn::GetAtt': [ds.config.domain, 'Arn'] };
+          arn = { 'Fn::Join': ['/', [{ 'Fn::GetAtt': [ds.config.domain, 'Arn'] }, '*']] };
         } else if (ds.config.endpoint) {
           const rx = /^https:\/\/([a-z0-9-]+\.\w{2}-[a-z]+-\d\.es\.amazonaws\.com)$/;
           const result = rx.exec(ds.config.endpoint);
@@ -708,7 +708,7 @@ class ServerlessAppsyncPlugin {
               'es',
               ds.config.region || config.region,
               { Ref: 'AWS::AccountId' },
-              `domain/${result[1]}`,
+              `domain/${result[1]}/*`,
             ]],
           };
         } else {

--- a/src/index.js
+++ b/src/index.js
@@ -282,7 +282,7 @@ class ServerlessAppsyncPlugin {
       .then((url) => {
         this.log(`Graphql Playground Server Running at: ${url}`);
       })
-      .then(() => new Promise(() => {}));
+      .then(() => new Promise(() => { }));
   }
 
   addResources() {
@@ -646,8 +646,7 @@ class ServerlessAppsyncPlugin {
         defaultStatements.push(defaultDynamoDBStatement);
         break;
       }
-      case 'RELATIONAL_DATABASE':
-      {
+      case 'RELATIONAL_DATABASE': {
         const dDbResourceArn = {
           'Fn::Join': [
             ':',
@@ -695,7 +694,7 @@ class ServerlessAppsyncPlugin {
         let arn;
         if (ds.config.domain) {
           arn = { 'Fn::Join': ['/', [{ 'Fn::GetAtt': [ds.config.domain, 'Arn'] }, '*']] };
-        } else if (ds.config.endpoint) {
+        } else if (ds.config.endpoint && typeof ds.config.endpoint === 'string') {
           const rx = /^https:\/\/([a-z0-9-]+\.\w{2}-[a-z]+-\d\.es\.amazonaws\.com)$/;
           const result = rx.exec(ds.config.endpoint);
           if (!result) {

--- a/src/index.js
+++ b/src/index.js
@@ -723,6 +723,7 @@ class ServerlessAppsyncPlugin {
             'es:ESHttpHead',
             'es:ESHttpPost',
             'es:ESHttpPut',
+            'es:ESHttpPatch',
           ],
           Effect: 'Allow',
           Resource: [arn],


### PR DESCRIPTION
This PR gets automatic role generation working, when using elastic search service as a data source, as discussed on #233 

Rather than overload the `endpoint` config key, this PR adds an optional `domain` config key which is to be a reference to a resource of type `AWS::Elasticsearch::Domain`.

If `domain` is provided, `endpoint` no longer needs to be provided - it is automatically derived from the `domain` reference.

This also adds `es:ESHttpPatch` to the list of actions enabled by automatic role generation, since it's one of the 6 basic ones listed in the [AWS docs on ElasticSearch IAM roles](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-ac.html).

I wouldn't view this as a backward-incompatible change because the previous version of this (with the overloaded `endpoint` key), AFAIK, didn't work.

I'm now using this on a live personal deployment of mine with the following config:

```yml
      - type: AMAZON_ELASTICSEARCH
        name: ElasticSearchDataSource
        config:
          domain: ElasticSearchDomain
```

Short and sweet.

Let me know if there's any changes or tweaks you'd like to see, thanks & cheers
