### PR TITLE
Update Created Function Naming

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -872,7 +872,7 @@ class ServerlessAppsyncPlugin {
           Type: 'AWS::AppSync::FunctionConfiguration',
           Properties: {
             ApiId: { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
-            Name: logicalIdFunctionConfiguration,
+            Name: tpl.name,
             DataSourceName: { 'Fn::GetAtt': [logicalIdDataSource, 'Name'] },
             RequestMappingTemplate: this.processTemplate(
               requestTemplate,


### PR DESCRIPTION
fixes https://github.com/sid88in/serverless-appsync-plugin/issues/321 — I updated it so that when Appsync functions are created it uses the name specified in the yml file in the `name` field, as opposed to before where it was using the `name` field prefixed with `GraphQlFunctionConfiguration`, which is the resource name.