### PR TITLE
Fix for v1.3.0 breaking change: Sanitize function name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -875,7 +875,7 @@ class ServerlessAppsyncPlugin {
           Type: 'AWS::AppSync::FunctionConfiguration',
           Properties: {
             ApiId: { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
-            Name: tpl.name,
+            Name: this.getCfnName(tpl.name),
             DataSourceName: { 'Fn::GetAtt': [logicalIdDataSource, 'Name'] },
             RequestMappingTemplate: this.processTemplate(
               requestTemplate,


### PR DESCRIPTION
It appears #321 broke deployment for projects that are using characters like `.` or `-` in their serverless.yml for function configuration names.

There's already a sanitization function present and in use in this project, this PR just applies it to the function name.