### PR TITLE
Update get-stack-value.js to fetch the stackname from provider.naming

### DIFF
--- a/src/get-stack-value.js
+++ b/src/get-stack-value.js
@@ -1,8 +1,8 @@
-function getServerlessStackName(service, provider) {
-  return `${service.getServiceName()}-${provider.getStage()}`;
+function getServerlessStackName(provider) {
+  return provider.naming.getStackName();
 }
 
-function getValue(service, provider, value, name) {
+function getValue(provider, value, name) {
   if (typeof value === 'string') {
     return Promise.resolve(value);
   } else if (value && typeof value.Ref === 'string') {
@@ -11,7 +11,7 @@ function getValue(service, provider, value, name) {
         'CloudFormation',
         'listStackResources',
         {
-          StackName: getServerlessStackName(service, provider),
+          StackName: getServerlessStackName(provider),
         },
       )
       .then((result) => {

--- a/src/index.js
+++ b/src/index.js
@@ -278,7 +278,7 @@ class ServerlessAppsyncPlugin {
   runGraphqlPlayground() {
     // Use the first config or config map
     const firstConfig = this.loadConfig()[0];
-    return runPlayground(this.serverless.service, this.provider, firstConfig, this.options)
+    return runPlayground(this.provider, firstConfig, this.options)
       .then((url) => {
         this.log(`Graphql Playground Server Running at: ${url}`);
       })


### PR DESCRIPTION
This change ensures that the stack name is fetched from serverless' provider.naming object.

It fixes a problem where the playground cannot be started against stacks with "custom" stack names (as opposed to being automatically named by serverless).