### PR TITLE
Fix: Triple quote string literal descriptions cause late validation failure

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -403,6 +403,29 @@ Object {
 }
 `;
 
+exports[`appsync config Schema is transformed into App Sync compatible syntax 1`] = `
+Object {
+  "GraphQlSchema": Object {
+    "Properties": Object {
+      "ApiId": Object {
+        "Fn::GetAtt": Array [
+          "GraphQlApi",
+          "ApiId",
+        ],
+      },
+      "Definition": "
+                    type Thing implements One, Another {
+            hello: ID!
+          }
+                    enum Method {
+            DELETE             GET           }
+        ",
+    },
+    "Type": "AWS::AppSync::GraphQLSchema",
+  },
+}
+`;
+
 exports[`appsync config appsync cloudwatch log group is created when logs enabled 1`] = `
 Object {
   "Properties": Object {

--- a/index.test.js
+++ b/index.test.js
@@ -115,6 +115,27 @@ describe('appsync config', () => {
     expect(resources.GraphQlApiLogGroup).toMatchSnapshot();
   });
 
+  test('Schema is transformed into App Sync compatible syntax', () => {
+    Object.assign(
+      config,
+      {
+        schema: `
+          """A valid schema"""
+          type Thing implements One & Another {
+            hello: ID!
+          }
+          """A valid enum"""
+          enum Method {
+            DELETE # Delete something
+            GET # Get something
+          }
+        `,
+      },
+    );
+    const schema = plugin.getGraphQLSchemaResource(config);
+    expect(schema).toMatchSnapshot();
+  });
+
   test('Datasource generates lambdaFunctionArn from functionName', () => {
     Object.assign(
       config,

--- a/src/index.js
+++ b/src/index.js
@@ -838,7 +838,7 @@ class ServerlessAppsyncPlugin {
     const appSyncSafeSchema = config.schema
       .replace(/"""[^"]*"""\n/g, '') // appsync does not support the new style descriptions
       .replace(/#.*\n/g, '') // appysnc does not support old-style # comments in enums, so remove them all
-      .replace(/ *& */g, ', ') // appsync does not support the standard '&', but the "unofficial" ',' join for interfaces
+      .replace(/ *& */g, ', '); // appsync does not support the standard '&', but the "unofficial" ',' join for interfaces
     return {
       [logicalIdGraphQLSchema]: {
         Type: 'AWS::AppSync::GraphQLSchema',

--- a/src/index.js
+++ b/src/index.js
@@ -835,11 +835,15 @@ class ServerlessAppsyncPlugin {
   getGraphQLSchemaResource(config) {
     const logicalIdGraphQLApi = this.getLogicalId(config, RESOURCE_API);
     const logicalIdGraphQLSchema = this.getLogicalId(config, RESOURCE_SCHEMA);
+    const appSyncSafeSchema = config.schema
+      .replace(/"""[^"]*"""\n/g, '') // appsync does not support the new style descriptions
+      .replace(/#.*\n/g, '') // appysnc does not support old-style # comments in enums, so remove them all
+      .replace(/ *& */g, ', ') // appsync does not support the standard '&', but the "unofficial" ',' join for interfaces
     return {
       [logicalIdGraphQLSchema]: {
         Type: 'AWS::AppSync::GraphQLSchema',
         Properties: {
-          Definition: config.schema,
+          Definition: appSyncSafeSchema,
           ApiId: { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
         },
       },


### PR DESCRIPTION
The GraphQL validation function, etc. is all based on GraphQL v14.5.8. Unfortunately there are some key differences between this schema version are the (now quite old) version AppSync uses. This results in cases where the validation step passes, and then the stack update fails.

This patch specifically addresses the three cases I have found (#317):
 * AppSync does not support the new style (`""" triple string literal """`) documentation/descriptions
 * AppSync does not support old-style (`#`) comments in Enums
 * AppSync uses the unofficial comma (install of the standard '&') join for interfaces

I've been using this patch in against our production schema for quite some time, but let me know if you think it's worth integrating.

(I appreciate there's now a GraphQL v15, but that's a whole other story!)