### PR TITLE
Generate ConditionCheckItem IAM role to support ConditionCheck

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -518,6 +518,7 @@ Object {
                   "dynamodb:UpdateItem",
                   "dynamodb:BatchGetItem",
                   "dynamodb:BatchWriteItem",
+                  "dynamodb:ConditionCheckItem",
                 ],
                 "Effect": "Allow",
                 "Resource": Array [

--- a/src/index.js
+++ b/src/index.js
@@ -635,6 +635,7 @@ class ServerlessAppsyncPlugin {
             'dynamodb:UpdateItem',
             'dynamodb:BatchGetItem',
             'dynamodb:BatchWriteItem',
+            'dynamodb:ConditionCheckItem',
           ],
           Effect: 'Allow',
           Resource: [


### PR DESCRIPTION
AppSync's TransactWriteItems now support DynamoDB's ConditionCheck.

It generates the IAM Role needed to run ConditionCheck.

[Resolver Mapping Template Reference for DynamoDB - AWS AppSync](https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html#aws-appsync-resolver-mapping-template-reference-dynamodb-transact-write-items)

[Using IAM with DynamoDB Transactions - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis-iam.html)