### PR TITLE
Add documentation about tags to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ custom:
       # ${exampleVar1} will be replaced with given value in all mapping templates
       exampleVar1: "${self:service.name}"
       exampleVar2: {'Fn::ImportValue': 'Some-external-stuff'}
+    tags: # Tags to be added to AppSync
+      key1: value1
+      key2: value2
 ```
 
 > Be sure to replace all variables that have been commented out, or have an empty value.


### PR DESCRIPTION
Add a description of the `tags` setting to README.md.

The feature was introduced in #247.
This is the documentation about it.
