### PR TITLE
Add documentation enable X-Ray to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ custom:
       # ${exampleVar1} will be replaced with given value in all mapping templates
       exampleVar1: "${self:service.name}"
       exampleVar2: {'Fn::ImportValue': 'Some-external-stuff'}
+    xrayEnabled: true # Bool, Optional. Enable X-Ray. disabled by default.
     tags: # Tags to be added to AppSync
       key1: value1
       key2: value2


### PR DESCRIPTION
Add a description of the X-Ray setting to README.md.

The feature was introduced in #304
This is the documentation about it.
