### PR TITLE
feat: add apiKeyRepairEnabled AppSync configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ custom:
   appSync:
     name:  # defaults to api
     # apiKey # only required for update-appsync/delete-appsync
+    # Set to `true` to automatically create a new, unique AppSync API key CFN object if the plugin-maintained
+    # CFN object is associated with an AppSync API key id that no longer exists.  This can happen on API key exipration
+    # or if an API key is manually deleted from the AWS console.  If this condition is present, deployment will
+    # fail without this option enabled because CFN will try to look up the deleted API key by ID and fail.
+    # This option is only relevant for authenticationType === API_KEY
+    # apiKeyRepairEnabled: true
     authenticationType: API_KEY or AWS_IAM or AMAZON_COGNITO_USER_POOLS or OPENID_CONNECT
     schema: # schema file or array of files to merge, defaults to schema.graphql
     # Caching options. Disabled by default
@@ -159,10 +165,10 @@ custom:
         #    - lambdaFunctionArn: The Arn for the Lambda function to use as the Conflict Handler.
         #    - conflictHandler: The Conflict Resolution strategy to perform in the event of a conflict.
         sync:
-          conflictDetection: VERSION # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appsync-resolver-syncconfig.html 
+          conflictDetection: VERSION # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appsync-resolver-syncconfig.html
           conflictHandler: OPTIMISTIC_CONCURRENCY # when not using lambda conflict handler choose The Conflict Resolution strategy to perform in the event of a conflict. OPTIMISTIC_CONCURRENCY / AUTOMERGE / LAMBDA
           functionName: graphql # The function name in your serverless.yml. Ignored if lambdaFunctionArn is provided.
-          lambdaFunctionArn: "arn:aws:lambda:{REGION}:{ACCOUNT_ID}:myFunction"       
+          lambdaFunctionArn: "arn:aws:lambda:{REGION}:{ACCOUNT_ID}:myFunction"
 
       - ${file({fileLocation}.yml)} # link to a file with arrays of mapping templates
     functionConfigurationsLocation: # defaults to mappingTemplatesLocation (mapping-templates)

--- a/__snapshots__/get-config.test.js.snap
+++ b/__snapshots__/get-config.test.js.snap
@@ -6,6 +6,7 @@ Array [
     "additionalAuthenticationProviders": Array [],
     "apiId": undefined,
     "apiKey": undefined,
+    "apiKeyRepairEnabled": undefined,
     "authenticationType": "AWS_IAM",
     "caching": undefined,
     "dataSources": Array [],
@@ -100,6 +101,7 @@ Array [
     "additionalAuthenticationProviders": Array [],
     "apiId": undefined,
     "apiKey": undefined,
+    "apiKeyRepairEnabled": undefined,
     "authenticationType": "AWS_IAM",
     "caching": undefined,
     "dataSources": Array [],
@@ -225,6 +227,7 @@ Array [
     "additionalAuthenticationProviders": Array [],
     "apiId": undefined,
     "apiKey": undefined,
+    "apiKeyRepairEnabled": undefined,
     "authenticationType": "AWS_IAM",
     "caching": undefined,
     "dataSources": Array [
@@ -355,6 +358,7 @@ Array [
     "additionalAuthenticationProviders": Array [],
     "apiId": undefined,
     "apiKey": undefined,
+    "apiKeyRepairEnabled": undefined,
     "authenticationType": "AWS_IAM",
     "caching": undefined,
     "dataSources": Array [
@@ -493,6 +497,7 @@ Array [
     "additionalAuthenticationProviders": Array [],
     "apiId": undefined,
     "apiKey": undefined,
+    "apiKeyRepairEnabled": undefined,
     "authenticationType": "AWS_IAM",
     "caching": undefined,
     "dataSources": Array [

--- a/index.test.js
+++ b/index.test.js
@@ -300,13 +300,13 @@ describe('appsync config', () => {
     });
   });
 
-  test('API_KEY config created', () => {
+  test('API_KEY config created', async () => {
     const apiConfig = {
       ...config,
       authenticationType: 'API_KEY',
     };
     const apiResources = plugin.getGraphQlApiEndpointResource(apiConfig);
-    const keyResources = plugin.getApiKeyResources(apiConfig);
+    const keyResources = await plugin.getApiKeyResources(apiConfig);
     const outputs = plugin.getApiKeyOutputs(apiConfig);
 
     expect(apiResources.GraphQlApi.Properties.AuthenticationType).toBe('API_KEY');
@@ -325,7 +325,7 @@ describe('appsync config', () => {
     });
   });
 
-  test('Additional authentication providers created', () => {
+  test('Additional authentication providers created', async () => {
     const apiConfig = {
       ...config,
       additionalAuthenticationProviders: [
@@ -356,7 +356,7 @@ describe('appsync config', () => {
     };
 
     const apiResources = plugin.getGraphQlApiEndpointResource(apiConfig);
-    const keyResources = plugin.getApiKeyResources(apiConfig);
+    const keyResources = await plugin.getApiKeyResources(apiConfig);
     const outputs = plugin.getApiKeyOutputs(apiConfig);
 
     expect(apiResources.GraphQlApi.Properties.AdditionalAuthenticationProviders).toMatchSnapshot();

--- a/src/get-config.js
+++ b/src/get-config.js
@@ -86,6 +86,7 @@ const getConfig = (config, provider, servicePath) => {
     name: config.name || 'api',
     apiId: config.apiId,
     apiKey: config.apiKey,
+    apiKeyRepairEnabled: config.apiKeyRepairEnabled,
     caching: config.caching,
     region: provider.region,
     authenticationType: config.authenticationType,


### PR DESCRIPTION
Set apiKeyRepairEnabled to `true` to automatically create a new, unique AppSync API key CFN object if the plugin-maintained CFN object is associated with an AppSync API key id that no longer exists.  This can happen on API key expiration or if an API key is manually deleted from the AWS console.  If this condition is present, the deployment will fail without this option enabled because CFN will try to look up the deleted API key by ID and fail.  This option is only relevant for authenticationType === API_KEY

* Modify mergeCustomProviderResources hook to be async
* Modify addResources to allow async calls
* Modify getApiKeyResources to handle key repairs when enabled
* Modify getApiKeyOutputs to use the resolvedLogicalApiKeyId resolved in getApiKeyResources