### PR TITLE
feat(apiKeys): api keys manager

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -541,6 +541,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "bsantare",
+      "name": "Brian Santarelli",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/29000522?v=4",
+      "profile": "https://github.com/bsantare",
+      "contributions": [
+        "ideas"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ custom:
     apiKeys:
       - name: john # name of the api key
         description: 'My api key'
-        expires: 30d # api key life time
+        expiresAfter: 30d # api key life time
       - name: jane
         description: "Jane's api key"
-        expires: 1y
+        expiresAt: '2021-03-09T16:00:00+00:00'
     # Array of additional authentication providers
     additionalAuthenticationProviders:
       - authenticationType: API_KEY
@@ -314,7 +314,7 @@ custom:
 
 #### Managing API keys
 
-Since v1.5.0, api keys management is supported. You can pass one or more api keys as an array in the `appSync.apiKeys` property.
+Since v1.5.0, api keys management is supported. You can pass one or more api keys configuration as an array in the `appSync.apiKeys` property.
 
 The keys can either be a string (name of the key with defaults) or an object of the following shape:
 
@@ -322,18 +322,23 @@ The keys can either be a string (name of the key with defaults) or an object of 
 |--------------| ------------------|------------|
 | name         | *auto-generated*  | Name of the key. This is used under the hood to differentiate keys in the deployment process.<br/><br/>Names are used in the Cfn resource name. Please, keep them short and without spaces or special characters to avoid issues. Key names are case sensitive. |
 | description  | *name of the key*   | A short description for that key |
-| expires      | 1y                | Expiration time for the key. <br/>Can be expressed in seconds or in "human" format. eg: `86400`, `30d`, `2w`, `1y` (See [jkroso/parse-duration](https://github.com/jkroso/parse-duration)).<br/>Min: 1d, max: 1y |
+| expiresAfter      | 1y                | Expiration time for the key. <br/>Can be expressed in seconds or in "human" format. eg: `86400`, `30d`, `2w`, `1y` (See [jkroso/parse-duration](https://github.com/jkroso/parse-duration)).<br/>Min: 1d, max: 1y |
+| expiresAt      | *one year from now* | A specific expiration date in ISO 8601 format. Or as a unix timestamp |
 | apiKeyId      | `undefined`      | the id if the api to update. Useful for when an api key has been created manually in the AWS console. |
+
+If both `expiresAfter` and `expiresAt` are specified, `expiresAfter` takes precedence.
 
 When naming keys, you need to be aware that changing the value will require the **replacement** of the api key.
 
 Unnamed keys are named automatically sequentially Key1, Key2, Key3 and so forth.
 
-:warning:  **Be careful when removing unnamed keys!!!**. For exemple, if you have 3 unnamed keys and you remove the second one in your list, Key3 will become Key2. As a result, it is former Key3 that **will be removed**. To workaround that, you could specify their auto-generated names before removing any unnamed keys (Key1, Key2 and Key3 in our example. Then remove Key2). As a rule of thumb, all keys should be named to avoid issues.
+:warning: **Be careful when removing unnamed keys!!!**. For exemple, if you have 3 unnamed keys and you remove the second one in your list, Key3 will become Key2. As a result, it is former Key3 that **will be removed**. To workaround that, you could specify their auto-generated names before removing any unnamed keys (Key1, Key2 and Key3 in our example. Then remove Key2). As a rule of thumb, all keys should be named to avoid issues.
 
-:bulb: If you have already deployed and an api key was previously auto-generated for you, you can add it to your yml template by naming it `Default` (case sensitive!!). Starting from there, you can add additional API keys.
+:bulb: If you have already deployed and an api key was previously auto-generated for you (either in version <1.5.0 or if you deployed without specifying the `apiKeys` property), you can add it to your yml template by naming it `Default` (case sensitive!!). Starting from there, you can add additional API keys.
 
 :bulb: If you want to revoke a key, delete it, or rename it.
+
+:bulb: If a key expires, or you have manually deleted it from the cosole, subsequent deployments will fail (after 60 days in the case it expires). You can fix that by simply removing the key from your yml file, or by renaming it (in which case, a new key will be generated).
 
 Example:
 ```yml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Tests](https://github.com/sid88in/serverless-appsync-plugin/workflows/Tests/badge.svg)](https://github.com/sid88in/serverless-appsync-plugin/actions?query=workflow%3ATests) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-59-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-60-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Deploy [AppSync](https://aws.amazon.com/appsync) API's in minutes using this [Serverless](https://www.serverless.com/) plugin.
@@ -70,6 +70,14 @@ custom:
       clientId:
       iatTTL:
       authTTL:
+
+    apiKeys:
+      - name: john # name of the api key
+        description: 'My api key'
+        expires: 30d # api key life time
+      - name: jane
+        description: "Jane's api key"
+        expires: 1y
     # Array of additional authentication providers
     additionalAuthenticationProviders:
       - authenticationType: API_KEY
@@ -304,6 +312,52 @@ custom:
         response: './mapping-templates/common-response.vtl' # defaults to {name}.response.vtl
 ```
 
+#### Managing API keys
+
+Since v1.5.0, api keys management is supported. You can pass one or more api keys as an array in the `appSync.apiKeys` property.
+
+The keys can either be a string (name of the key with defaults) or an object of the following shape:
+
+|   property   |      default      | description|
+|--------------| ------------------|------------|
+| name         | *auto-generated*  | Name of the key. This is used under the hood to differentiate keys in the deployment process.<br/><br/>Names are used in the Cfn resource name. Please, keep them short and without spaces or special characters to avoid issues. Key names are case sensitive. |
+| description  | *name of the key*   | A short description for that key |
+| expires      | 1y                | Expiration time for the key. <br/>Can be expressed in seconds or in "human" format. eg: `86400`, `30d`, `2w`, `1y` (See [jkroso/parse-duration](https://github.com/jkroso/parse-duration)).<br/>Min: 1d, max: 1y |
+| apiKeyId      | `undefined`      | the id if the api to update. Useful for when an api key has been created manually in the AWS console. |
+
+When naming keys, you need to be aware that changing the value will require the **replacement** of the api key.
+
+Unnamed keys are named automatically sequentially Key1, Key2, Key3 and so forth.
+
+:warning:  **Be careful when removing unnamed keys!!!**. For exemple, if you have 3 unnamed keys and you remove the second one in your list, Key3 will become Key2. As a result, it is former Key3 that **will be removed**. To workaround that, you could specify their auto-generated names before removing any unnamed keys (Key1, Key2 and Key3 in our example. Then remove Key2). As a rule of thumb, all keys should be named to avoid issues.
+
+:bulb: If you have already deployed and an api key was previously auto-generated for you, you can add it to your yml template by naming it `Default` (case sensitive!!). Starting from there, you can add additional API keys.
+
+:bulb: If you want to revoke a key, delete it, or rename it.
+
+Example:
+```yml
+apiKeys:
+  - name: Default # default API key. Use this name if you already have an auto-generated API key
+    description: Default api key
+    expires: 1y # 1 year timelife
+  - Mark # inline named key, with defaults (1 year duration)
+  - name: John
+    description: John api key
+    expires: 30d
+  - name: Jane
+    expires: 2d
+  - description: Unnamed key # first unnamed key (Key1)
+  - expires: 30d # second unnamed key (Key2)
+```
+
+:bulb:  Finally, if you dont't want serverless to handle keys for you, just pass an empty array:
+
+```yml
+# Handle keys manually in the aws console.
+apiKeys: []
+```
+
 ## Cli Usage
 
 ### `serverless deploy`
@@ -484,6 +538,7 @@ Thanks goes to these wonderful people :clap:
     <td align="center"><a href="https://github.com/nadalfederer"><img src="https://avatars1.githubusercontent.com/u/6043510?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Vladimir Lebedev</b></sub></a><br /><a href="https://github.com/sid88in/serverless-appsync-plugin/commits?author=nadalfederer" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/Znergy"><img src="https://avatars1.githubusercontent.com/u/18511689?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ryan Jones</b></sub></a><br /><a href="https://github.com/sid88in/serverless-appsync-plugin/commits?author=Znergy" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/vicary"><img src="https://avatars0.githubusercontent.com/u/85772?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Vicary A.</b></sub></a><br /><a href="https://github.com/sid88in/serverless-appsync-plugin/commits?author=vicary" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/bsantare"><img src="https://avatars2.githubusercontent.com/u/29000522?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Brian Santarelli</b></sub></a><br /><a href="#ideas-bsantare" title="Ideas, Planning, & Feedback">🤔</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ The keys can either be a string (name of the key with defaults) or an object of 
 |--------------| ------------------|------------|
 | name         | *auto-generated*  | Name of the key. This is used under the hood to differentiate keys in the deployment process.<br/><br/>Names are used in the Cfn resource name. Please, keep them short and without spaces or special characters to avoid issues. Key names are case sensitive. |
 | description  | *name of the key*   | A short description for that key |
-| expiresAfter      | 1y                | Expiration time for the key. <br/>Can be expressed in hours or in "human" format. eg: `24`, `30d`, `2w`, `1y` (See [jkroso/parse-duration](https://github.com/jkroso/parse-duration)).<br/>Min: 1d, max: 1y |
+| expiresAfter | 365d                | Expiration time for the key. <br/>Can be expressed in hours or in "human" format (As in momentjs [add](https://momentjscom.readthedocs.io/en/latest/moment/03-manipulating/01-add/)).<br/>eg: `24`, `30d`, `1M`, `2w`, `1y`<br/>Min: 1d, max: 1y |
 | expiresAt      | *one year from now* | A specific expiration date in ISO 8601 format. Or as a unix timestamp |
 | apiKeyId      | `undefined`      | the id if the api to update. Useful for when an api key has been created manually in the AWS console. |
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ The keys can either be a string (name of the key with defaults) or an object of 
 |--------------| ------------------|------------|
 | name         | *auto-generated*  | Name of the key. This is used under the hood to differentiate keys in the deployment process.<br/><br/>Names are used in the Cfn resource name. Please, keep them short and without spaces or special characters to avoid issues. Key names are case sensitive. |
 | description  | *name of the key*   | A short description for that key |
-| expiresAfter      | 1y                | Expiration time for the key. <br/>Can be expressed in seconds or in "human" format. eg: `86400`, `30d`, `2w`, `1y` (See [jkroso/parse-duration](https://github.com/jkroso/parse-duration)).<br/>Min: 1d, max: 1y |
+| expiresAfter      | 1y                | Expiration time for the key. <br/>Can be expressed in hours or in "human" format. eg: `24`, `30d`, `2w`, `1y` (See [jkroso/parse-duration](https://github.com/jkroso/parse-duration)).<br/>Min: 1d, max: 1y |
 | expiresAt      | *one year from now* | A specific expiration date in ISO 8601 format. Or as a unix timestamp |
 | apiKeyId      | `undefined`      | the id if the api to update. Useful for when an api key has been created manually in the AWS console. |
 

--- a/__snapshots__/get-config.test.js.snap
+++ b/__snapshots__/get-config.test.js.snap
@@ -4,20 +4,15 @@ exports[`Schema as array 1`] = `
 Array [
   Object {
     "additionalAuthenticationProviders": Array [],
-    "apiId": undefined,
-    "apiKey": undefined,
     "authenticationType": "AWS_IAM",
-    "caching": undefined,
     "dataSources": Array [],
     "defaultMappingTemplates": Object {},
     "functionConfigurations": Array [],
     "functionConfigurationsLocation": "mapping-templates",
     "isSingleConfig": true,
-    "logConfig": undefined,
     "mappingTemplates": Array [],
     "mappingTemplatesLocation": "mapping-templates",
     "name": "api",
-    "openIdConnectConfig": undefined,
     "region": "us-east-1",
     "schema": "type Mutation {
   
@@ -87,8 +82,6 @@ schema {
 }
 ",
     "substitutions": Object {},
-    "tags": undefined,
-    "userPoolConfig": undefined,
     "xrayEnabled": false,
   },
 ]
@@ -98,20 +91,15 @@ exports[`Schema as string 1`] = `
 Array [
   Object {
     "additionalAuthenticationProviders": Array [],
-    "apiId": undefined,
-    "apiKey": undefined,
     "authenticationType": "AWS_IAM",
-    "caching": undefined,
     "dataSources": Array [],
     "defaultMappingTemplates": Object {},
     "functionConfigurations": Array [],
     "functionConfigurationsLocation": "mapping-templates",
     "isSingleConfig": true,
-    "logConfig": undefined,
     "mappingTemplates": Array [],
     "mappingTemplatesLocation": "mapping-templates",
     "name": "api",
-    "openIdConnectConfig": undefined,
     "region": "us-east-1",
     "schema": "type Mutation {
 	# Create a tweet for a user
@@ -208,8 +196,6 @@ schema {
 }
 ",
     "substitutions": Object {},
-    "tags": undefined,
-    "userPoolConfig": undefined,
     "xrayEnabled": false,
   },
 ]
@@ -223,10 +209,7 @@ exports[`datasources as array 1`] = `
 Array [
   Object {
     "additionalAuthenticationProviders": Array [],
-    "apiId": undefined,
-    "apiKey": undefined,
     "authenticationType": "AWS_IAM",
-    "caching": undefined,
     "dataSources": Array [
       Object {
         "name": "users",
@@ -241,11 +224,9 @@ Array [
     "functionConfigurations": Array [],
     "functionConfigurationsLocation": "mapping-templates",
     "isSingleConfig": true,
-    "logConfig": undefined,
     "mappingTemplates": Array [],
     "mappingTemplatesLocation": "mapping-templates",
     "name": "api",
-    "openIdConnectConfig": undefined,
     "region": "us-east-1",
     "schema": "type Mutation {
 	# Create a tweet for a user
@@ -342,8 +323,6 @@ schema {
 }
 ",
     "substitutions": Object {},
-    "tags": undefined,
-    "userPoolConfig": undefined,
     "xrayEnabled": false,
   },
 ]
@@ -353,10 +332,7 @@ exports[`datasources as array form different files (array of arrays or objects) 
 Array [
   Object {
     "additionalAuthenticationProviders": Array [],
-    "apiId": undefined,
-    "apiKey": undefined,
     "authenticationType": "AWS_IAM",
-    "caching": undefined,
     "dataSources": Array [
       Object {
         "name": "users",
@@ -379,11 +355,9 @@ Array [
     "functionConfigurations": Array [],
     "functionConfigurationsLocation": "mapping-templates",
     "isSingleConfig": true,
-    "logConfig": undefined,
     "mappingTemplates": Array [],
     "mappingTemplatesLocation": "mapping-templates",
     "name": "api",
-    "openIdConnectConfig": undefined,
     "region": "us-east-1",
     "schema": "type Mutation {
 	# Create a tweet for a user
@@ -480,8 +454,6 @@ schema {
 }
 ",
     "substitutions": Object {},
-    "tags": undefined,
-    "userPoolConfig": undefined,
     "xrayEnabled": false,
   },
 ]
@@ -491,10 +463,7 @@ exports[`returns valid config 1`] = `
 Array [
   Object {
     "additionalAuthenticationProviders": Array [],
-    "apiId": undefined,
-    "apiKey": undefined,
     "authenticationType": "AWS_IAM",
-    "caching": undefined,
     "dataSources": Array [
       Object {
         "name": "users",
@@ -509,11 +478,9 @@ Array [
     "functionConfigurations": Array [],
     "functionConfigurationsLocation": "mapping-templates",
     "isSingleConfig": true,
-    "logConfig": undefined,
     "mappingTemplates": Array [],
     "mappingTemplatesLocation": "mapping-templates",
     "name": "api",
-    "openIdConnectConfig": undefined,
     "region": "us-east-1",
     "schema": "type Mutation {
 	# Create a tweet for a user
@@ -610,8 +577,6 @@ schema {
 }
 ",
     "substitutions": Object {},
-    "tags": undefined,
-    "userPoolConfig": undefined,
     "xrayEnabled": false,
   },
 ]

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -543,11 +543,15 @@ Object {
 }
 `;
 
-exports[`api keys should fail with invalid duration 1`] = `"Could not parse foobar as a valid diration"`;
+exports[`api keys should fail with a date > 1 year 1`] = `"Api Key MyKey must be valid for a minimum of 1 day and a maximum of 365 days."`;
 
-exports[`api keys should fail with too long duration 1`] = `"Api Key MyKey must be valid for minimum of 1 day and a maximum of 365 days."`;
+exports[`api keys should fail with invalid duration 1`] = `"Could not parse foobar as a valid duration"`;
 
-exports[`api keys should fail with too short duration 1`] = `"Api Key MyKey must be valid for minimum of 1 day and a maximum of 365 days."`;
+exports[`api keys should fail with too long duration 1`] = `"Api Key MyKey must be valid for a minimum of 1 day and a maximum of 365 days."`;
+
+exports[`api keys should fail with too short duration 1`] = `"Api Key MyKey must be valid for a minimum of 1 day and a maximum of 365 days."`;
+
+exports[`api keys should fail with with a date < 1 day 1`] = `"Api Key MyKey must be valid for a minimum of 1 day and a maximum of 365 days."`;
 
 exports[`api keys should generate several keys 1`] = `
 Object {
@@ -603,7 +607,7 @@ Object {
       },
       "ApiKeyId": undefined,
       "Description": "John's key",
-      "Expires": 1615419000,
+      "Expires": 1615305600,
     },
     "Type": "AWS::AppSync::ApiKey",
   },

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -543,6 +543,154 @@ Object {
 }
 `;
 
+exports[`api keys should fail with invalid duration 1`] = `"Could not parse foobar as a valid diration"`;
+
+exports[`api keys should fail with too long duration 1`] = `"Api Key MyKey must be valid for minimum of 1 day and a maximum of 365 days."`;
+
+exports[`api keys should fail with too short duration 1`] = `"Api Key MyKey must be valid for minimum of 1 day and a maximum of 365 days."`;
+
+exports[`api keys should generate several keys 1`] = `
+Object {
+  "GraphQlApiKeyDefault": Object {
+    "Properties": Object {
+      "ApiId": Object {
+        "Fn::GetAtt": Array [
+          "GraphQlApi",
+          "ApiId",
+        ],
+      },
+      "ApiKeyId": undefined,
+      "Description": "Default Key",
+      "Expires": 1610121600,
+    },
+    "Type": "AWS::AppSync::ApiKey",
+  },
+  "GraphQlApiKeyInlineKey": Object {
+    "Properties": Object {
+      "ApiId": Object {
+        "Fn::GetAtt": Array [
+          "GraphQlApi",
+          "ApiId",
+        ],
+      },
+      "ApiKeyId": undefined,
+      "Description": "InlineKey",
+      "Expires": 1639065600,
+    },
+    "Type": "AWS::AppSync::ApiKey",
+  },
+  "GraphQlApiKeyJane": Object {
+    "Properties": Object {
+      "ApiId": Object {
+        "Fn::GetAtt": Array [
+          "GraphQlApi",
+          "ApiId",
+        ],
+      },
+      "ApiKeyId": undefined,
+      "Description": "Jane",
+      "Expires": 1639065600,
+    },
+    "Type": "AWS::AppSync::ApiKey",
+  },
+  "GraphQlApiKeyJohn": Object {
+    "Properties": Object {
+      "ApiId": Object {
+        "Fn::GetAtt": Array [
+          "GraphQlApi",
+          "ApiId",
+        ],
+      },
+      "ApiKeyId": undefined,
+      "Description": "John's key",
+      "Expires": 1615419000,
+    },
+    "Type": "AWS::AppSync::ApiKey",
+  },
+  "GraphQlApiKeyKey1": Object {
+    "Properties": Object {
+      "ApiId": Object {
+        "Fn::GetAtt": Array [
+          "GraphQlApi",
+          "ApiId",
+        ],
+      },
+      "ApiKeyId": undefined,
+      "Description": "Unnamed Key1",
+      "Expires": 1607619600,
+    },
+    "Type": "AWS::AppSync::ApiKey",
+  },
+  "GraphQlApiKeyKey2": Object {
+    "Properties": Object {
+      "ApiId": Object {
+        "Fn::GetAtt": Array [
+          "GraphQlApi",
+          "ApiId",
+        ],
+      },
+      "ApiKeyId": "da2-7hfy4mjkdmh64lp0une7yht765",
+      "Description": "Unnamed Key2",
+      "Expires": 1639065600,
+    },
+    "Type": "AWS::AppSync::ApiKey",
+  },
+}
+`;
+
+exports[`api keys should generate several keys 2`] = `
+Object {
+  "GraphQlApiKeyDefault": Object {
+    "Value": Object {
+      "Fn::GetAtt": Array [
+        "GraphQlApiKeyDefault",
+        "ApiKey",
+      ],
+    },
+  },
+  "GraphQlApiKeyInlineKey": Object {
+    "Value": Object {
+      "Fn::GetAtt": Array [
+        "GraphQlApiKeyInlineKey",
+        "ApiKey",
+      ],
+    },
+  },
+  "GraphQlApiKeyJane": Object {
+    "Value": Object {
+      "Fn::GetAtt": Array [
+        "GraphQlApiKeyJane",
+        "ApiKey",
+      ],
+    },
+  },
+  "GraphQlApiKeyJohn": Object {
+    "Value": Object {
+      "Fn::GetAtt": Array [
+        "GraphQlApiKeyJohn",
+        "ApiKey",
+      ],
+    },
+  },
+  "GraphQlApiKeyKey1": Object {
+    "Value": Object {
+      "Fn::GetAtt": Array [
+        "GraphQlApiKeyKey1",
+        "ApiKey",
+      ],
+    },
+  },
+  "GraphQlApiKeyKey2": Object {
+    "Value": Object {
+      "Fn::GetAtt": Array [
+        "GraphQlApiKeyKey2",
+        "ApiKey",
+      ],
+    },
+  },
+}
+`;
+
 exports[`appsync config Additional authentication providers created 1`] = `
 Array [
   Object {
@@ -586,8 +734,9 @@ Object {
         "ApiId",
       ],
     },
-    "Description": "serverless-appsync-plugin: AppSync API Key for GraphQlApiKeyDefault",
-    "Expires": 31536010,
+    "ApiKeyId": undefined,
+    "Description": "Auto-generated api key",
+    "Expires": 1639065600,
   },
   "Type": "AWS::AppSync::ApiKey",
 }
@@ -711,6 +860,25 @@ Object {
       "Type": "AWS_LAMBDA",
     },
     "Type": "AWS::AppSync::DataSource",
+  },
+}
+`;
+
+exports[`appsync config Deault API_KEY config created 1`] = `
+Object {
+  "GraphQlApiKeyDefault": Object {
+    "Properties": Object {
+      "ApiId": Object {
+        "Fn::GetAtt": Array [
+          "GraphQlApi",
+          "ApiId",
+        ],
+      },
+      "ApiKeyId": undefined,
+      "Description": "Auto-generated api key",
+      "Expires": 1639065600,
+    },
+    "Type": "AWS::AppSync::ApiKey",
   },
 }
 `;

--- a/index.test.js
+++ b/index.test.js
@@ -4,7 +4,6 @@ const chalk = require('chalk');
 const Serverless = require('serverless/lib/Serverless');
 const ServerlessAppsyncPlugin = require('./src');
 const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider.js');
-const moment = require('moment');
 
 let serverless;
 let plugin;

--- a/index.test.js
+++ b/index.test.js
@@ -1428,20 +1428,4 @@ describe('api keys', () => {
     };
     expect(() => plugin.getApiKeyResources(apiConfig)).toThrowErrorMatchingSnapshot();
   });
-
-  it('should auto-fix 24h durations to 25h', () => {
-    const apiConfig = {
-      ...config,
-      authenticationType: 'API_KEY',
-      apiKeys: [
-        {
-          name: 'MyKey',
-          expiresAfter: '24h',
-        },
-      ],
-    };
-    const keys = plugin.getApiKeyResources(apiConfig);
-    expect(keys.GraphQlApiKeyMyKey.Properties.Expires)
-      .toEqual(moment.utc().startOf('hour').add(25, 'hours').unix());
-  });
 });

--- a/index.test.js
+++ b/index.test.js
@@ -8,7 +8,9 @@ const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider.js'
 let serverless;
 let plugin;
 let config;
-jest.spyOn(Date, 'now').mockImplementation(() => 10000);
+
+// 2020-12-09T16:24:22+00:00
+jest.spyOn(Date, 'now').mockImplementation(() => 1607531062000);
 
 jest.mock('fs');
 jest.spyOn(fs, 'readFileSync').mockImplementation(path => `Content: ${path}`);
@@ -321,7 +323,7 @@ describe('appsync config', () => {
     });
   });
 
-  test('API_KEY config created', () => {
+  test('Deault API_KEY config created', () => {
     const apiConfig = {
       ...config,
       authenticationType: 'API_KEY',
@@ -331,14 +333,7 @@ describe('appsync config', () => {
     const outputs = plugin.getApiKeyOutputs(apiConfig);
 
     expect(apiResources.GraphQlApi.Properties.AuthenticationType).toBe('API_KEY');
-    expect(keyResources.GraphQlApiKeyDefault).toEqual({
-      Type: 'AWS::AppSync::ApiKey',
-      Properties: {
-        ApiId: { 'Fn::GetAtt': ['GraphQlApi', 'ApiId'] },
-        Description: 'serverless-appsync-plugin: AppSync API Key for GraphQlApiKeyDefault',
-        Expires: Math.floor(Date.now() / 1000) + (365 * 24 * 60 * 60),
-      },
-    });
+    expect(keyResources).toMatchSnapshot();
     expect(outputs).toEqual({
       GraphQlApiKeyDefault: {
         Value: { 'Fn::GetAtt': ['GraphQlApiKeyDefault', 'ApiKey'] },
@@ -381,6 +376,7 @@ describe('appsync config', () => {
     const outputs = plugin.getApiKeyOutputs(apiConfig);
 
     expect(apiResources.GraphQlApi.Properties.AdditionalAuthenticationProviders).toMatchSnapshot();
+    expect(keyResources).toHaveProperty('GraphQlApiKeyDefault');
     expect(keyResources.GraphQlApiKeyDefault).toMatchSnapshot();
     expect(outputs).toEqual({
       GraphQlApiKeyDefault: {
@@ -1321,5 +1317,102 @@ describe('SyncConfig', () => {
 
     const result = plugin.getResolverResources(config);
     expect(result).toMatchSnapshot();
+  });
+});
+
+describe('api keys', () => {
+  it('should generate several keys', () => {
+    const apiConfig = {
+      ...config,
+      authenticationType: 'API_KEY',
+      apiKeys: [
+        {
+          name: 'Default',
+          description: 'Default Key',
+          expires: '30d',
+        },
+        {
+          description: 'Unnamed Key1',
+          expires: '1d',
+        },
+        {
+          description: 'Unnamed Key2',
+          apiKeyId: 'da2-7hfy4mjkdmh64lp0une7yht765',
+        },
+        {
+          name: 'John',
+          description: 'John\'s key',
+          expires: '3month',
+        },
+        {
+          name: 'Jane',
+          expires: '1y',
+        },
+        'InlineKey',
+      ],
+    };
+    const keyResources = plugin.getApiKeyResources(apiConfig);
+    const outputs = plugin.getApiKeyOutputs(apiConfig);
+
+    expect(keyResources).toMatchSnapshot();
+    expect(outputs).toMatchSnapshot();
+  });
+
+  it('should fail with invalid duration', () => {
+    const apiConfig = {
+      ...config,
+      authenticationType: 'API_KEY',
+      apiKeys: [
+        {
+          name: 'MyKey',
+          expires: 'foobar',
+        },
+      ],
+    };
+    expect(() => plugin.getApiKeyResources(apiConfig)).toThrowErrorMatchingSnapshot();
+  });
+
+  it('should fail with too long duration', () => {
+    const apiConfig = {
+      ...config,
+      authenticationType: 'API_KEY',
+      apiKeys: [
+        {
+          name: 'MyKey',
+          expires: '2y',
+        },
+      ],
+    };
+    expect(() => plugin.getApiKeyResources(apiConfig)).toThrowErrorMatchingSnapshot();
+  });
+
+  it('should fail with too short duration', () => {
+    const apiConfig = {
+      ...config,
+      authenticationType: 'API_KEY',
+      apiKeys: [
+        {
+          name: 'MyKey',
+          expires: '1h',
+        },
+      ],
+    };
+    expect(() => plugin.getApiKeyResources(apiConfig)).toThrowErrorMatchingSnapshot();
+  });
+
+  it('should auto-fix 24h durations to 25h', () => {
+    const apiConfig = {
+      ...config,
+      authenticationType: 'API_KEY',
+      apiKeys: [
+        {
+          name: 'MyKey',
+          expires: '24h',
+        },
+      ],
+    };
+    const keys = plugin.getApiKeyResources(apiConfig);
+    expect(keys.GraphQlApiKeyMyKey.Properties.Expires)
+      .toEqual(((Math.floor(Date.now() / 1000 / 3600) * 3600) + (3600 * 25)));
   });
 });

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "graphql-playground-middleware-koa": "^1.6.4",
     "koa": "^2.5.2",
     "moment": "^2.29.1",
-    "parse-duration": "^0.4.4",
     "ramda": "^0.25.0"
   },
   "peerDependencies": {},

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "graphql": "^14.5.8",
     "graphql-playground-middleware-koa": "^1.6.4",
     "koa": "^2.5.2",
+    "parse-duration": "^0.4.4",
     "ramda": "^0.25.0"
   },
   "peerDependencies": {},

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "graphql": "^14.5.8",
     "graphql-playground-middleware-koa": "^1.6.4",
     "koa": "^2.5.2",
+    "moment": "^2.29.1",
     "parse-duration": "^0.4.4",
     "ramda": "^0.25.0"
   },

--- a/src/get-config.js
+++ b/src/get-config.js
@@ -83,16 +83,12 @@ const getConfig = (config, provider, servicePath) => {
   }
 
   return {
+    ...config,
     name: config.name || 'api',
-    apiId: config.apiId,
-    apiKey: config.apiKey,
-    caching: config.caching,
     region: provider.region,
     authenticationType: config.authenticationType,
     additionalAuthenticationProviders: config.additionalAuthenticationProviders || [],
     schema: schemaContent,
-    userPoolConfig: config.userPoolConfig,
-    openIdConnectConfig: config.openIdConnectConfig,
     // TODO verify dataSources structure
     dataSources,
     defaultMappingTemplates: config.defaultMappingTemplates || {},
@@ -100,10 +96,8 @@ const getConfig = (config, provider, servicePath) => {
     mappingTemplates,
     functionConfigurationsLocation,
     functionConfigurations,
-    logConfig: config.logConfig,
     substitutions: config.substitutions || {},
     xrayEnabled: config.xrayEnabled || false,
-    tags: config.tags,
   };
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -472,10 +472,9 @@ class ServerlessAppsyncPlugin {
 
         let expires;
         if (expiresAfter) {
-          const duration = parseDuration(expiresAfter);
           expires = moment.utc()
             .startOf('hour')
-            .add(duration);
+            .add(parseDuration(expiresAfter));
         } else if (expiresAt) {
           expires = moment.utc(expiresAt);
         } else {

--- a/src/index.js
+++ b/src/index.js
@@ -472,31 +472,17 @@ class ServerlessAppsyncPlugin {
 
         let expires;
         if (expiresAfter) {
-          let duration = parseDuration(expiresAfter);
-          if (duration === null) {
-            throw new Error(`Could not parse ${expiresAfter} as a valid duration`);
-          }
-
-          // Minimum duration is 1 day from 'now'
-          // However, api key expiry is rounded down to the hour.
-          // meaning the minimum expiry date is in fact 25 hours
-          // We accept 24h durations for simplicity of use
-          // but fix them to be 25
-          // Anything < 24h will be kept to make sure the validation fails later
-          if (duration >= 24) {
-            duration = Math.max(duration, 25);
-          }
-
+          const duration = parseDuration(expiresAfter);
           expires = moment.utc()
             .startOf('hour')
-            .add(duration, 'hours');
+            .add(duration);
         } else if (expiresAt) {
           expires = moment.utc(expiresAt);
         } else {
           // 1 year by default
           expires = moment.utc()
             .startOf('hour')
-            .add(1, 'year');
+            .add(365, 'days');
         }
 
         if (expires.isBefore(moment.utc().add(1, 'day'))

--- a/src/index.js
+++ b/src/index.js
@@ -483,13 +483,13 @@ class ServerlessAppsyncPlugin {
           // We accept 24h durations for simplicity of use
           // but fix them to be 25
           // Anything < 24h will be kept to make sure the validation fails later
-          if (duration >= 3600 * 24) {
-            duration = Math.max(duration, 3600 * 25);
+          if (duration >= 24) {
+            duration = Math.max(duration, 25);
           }
 
           expires = moment.utc()
             .startOf('hour')
-            .add(duration, 'seconds');
+            .add(duration, 'hours');
         } else if (expiresAt) {
           expires = moment.utc(expiresAt);
         } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,7 +25,7 @@ module.exports = {
         let unit = match[2];
 
         // 1 year could be 366 days on or before leap year,
-        // which would fail. Swap to 365 days
+        // which would fail. Swap for 365 days
         if (input.match(/^1y(ears?)?$/)) {
           amount = 365;
           unit = 'days';

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,20 @@
+const parseStringDuration = require('parse-duration');
+
+// override default
+parseStringDuration.y = parseStringDuration.d * 365;
+
+module.exports = {
+  parseDuration: (duration) => {
+    if (typeof duration === 'number') {
+      return duration;
+    } else if (typeof duration === 'string') {
+      if (/^\d+$/.test(duration)) {
+        return parseInt(duration, 10);
+      }
+
+      return parseStringDuration(duration, 's');
+    }
+
+    return duration;
+  },
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,7 @@ module.exports = {
         return parseInt(duration, 10);
       }
 
-      return parseStringDuration(duration, 's');
+      return parseStringDuration(duration, 'h');
     }
 
     return duration;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,18 +1,52 @@
-const parseStringDuration = require('parse-duration');
+const moment = require('moment');
 
-// override default
-parseStringDuration.y = parseStringDuration.d * 365;
+const timeUnits = [
+  'years?', 'y',
+  'quarters?', 'Q',
+  'months?', 'M',
+  'weeks?', 'w',
+  'days?', 'd',
+  'hours?', 'h',
+  'minutes?', 'm',
+  'seconds?', 's',
+  'milliseconds?', 'ms',
+];
 
 module.exports = {
-  parseDuration: (duration) => {
-    if (typeof duration === 'number') {
-      return duration;
-    } else if (typeof duration === 'string') {
-      if (/^\d+$/.test(duration)) {
-        return parseInt(duration, 10);
-      }
+  parseDuration: (input) => {
+    let duration;
+    if (typeof input === 'number') {
+      duration = moment.duration(input, 'hours');
+    } else if (typeof input === 'string') {
+      const regexp = new RegExp(`^(\\d+)(${timeUnits.join('|')})$`);
+      const match = input.match(regexp);
+      if (match) {
+        let amount = match[1];
+        let unit = match[2];
 
-      return parseStringDuration(duration, 'h');
+        // 1 year could be 366 days on or before leap year,
+        // which would fail. Swap to 365 days
+        if (input.match(/^1y(ears?)?$/)) {
+          amount = 365;
+          unit = 'days';
+        }
+
+        duration = moment.duration(amount, unit || 'hours');
+      } else {
+        throw new Error(`Could not parse ${input} as a valid duration`);
+      }
+    } else {
+      throw new Error(`Could not parse ${input} as a valid duration`);
+    }
+
+    // Minimum duration is 1 day from 'now'
+    // However, api key expiry is rounded down to the hour.
+    // meaning the minimum expiry date is in fact 25 hours
+    // We accept 24h durations for simplicity of use
+    // but fix them to be 25
+    // Anything < 24h will be kept to make sure the validation fails later
+    if (duration.asHours() >= 24 && duration.asHours() < 25) {
+      duration = moment.duration(25, 'hours');
     }
 
     return duration;

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,0 +1,27 @@
+const { parseDuration } = require('./utils');
+
+describe('parseDuration', () => {
+  it('should parse valid duration', () => {
+    expect(parseDuration('2d').toString()).toEqual('P2D');
+    expect(parseDuration('2day').toString()).toEqual('P2D');
+    expect(parseDuration('2days').toString()).toEqual('P2D');
+    expect(parseDuration('365d').toString()).toEqual('P365D');
+  });
+
+  it('should throw on invalid duration', () => {
+    expect(() => parseDuration('foo')).toThrowError();
+  });
+
+
+  it('should auto-fix 24h durations to 25h', () => {
+    expect(parseDuration(24).toString()).toEqual('PT25H');
+    expect(parseDuration('1day').toString()).toEqual('PT25H');
+    expect(parseDuration('1d').toString()).toEqual('PT25H');
+    expect(parseDuration('24h').toString()).toEqual('PT25H');
+    expect(parseDuration('1440m').toString()).toEqual('PT25H');
+  });
+
+  it('should auto-fix 1y durations to 365 days', () => {
+    expect(parseDuration('1y').toString()).toEqual('P365D');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5339,6 +5339,11 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-duration@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/parse-duration/-/parse-duration-0.4.4.tgz#11c0f51a689e97d06c57bd772f7fda7dc013243c"
+  integrity sha512-KbAJuYGUhZkB9gotDiKLnZ7Z3VTacK3fgwmDdB6ZVDtJbMBT6MfLga0WJaYpPDu0mzqT0NgHtHDt5PY4l0nidg==
+
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4858,6 +4858,11 @@ moment@^2.24.0:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
+moment@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5344,11 +5344,6 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
-parse-duration@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/parse-duration/-/parse-duration-0.4.4.tgz#11c0f51a689e97d06c57bd772f7fda7dc013243c"
-  integrity sha512-KbAJuYGUhZkB9gotDiKLnZ7Z3VTacK3fgwmDdB6ZVDtJbMBT6MfLga0WJaYpPDu0mzqT0NgHtHDt5PY4l0nidg==
-
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"


### PR DESCRIPTION
Replaces/fixes #373 

Add Api key manager.
Features:
- Allow specifying more than one api key
- Allow custom values for `expiry`, `description` and `apikeyId` (See [Cfn doc](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-apikey.html)).
- Use names to identify keys.
- Allow op-out of Api key management
