### PR TITLE
Config for issue #268: API name as LogGroupName

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ custom:
       loggingRoleArn: { Fn::GetAtt: [AppSyncLoggingServiceRole, Arn] } # Where AppSyncLoggingServiceRole is a role with CloudWatch Logs write access
       level: ERROR # Logging Level: NONE | ERROR | ALL
       excludeVerboseContent: false
+      #logGroupName: API_ID (default, not required) or API_NAME (API name prefixed for better differentiating APIs)
     defaultMappingTemplates: # default templates. Useful for Lambda templates that are often repetitive. Will be used if the template is not specified in a resolver
       request: my.request.template.tpl # or, e.g: false for Direct lambdas
       response: my.response.template.tpl # or e.g.: false for Direct lambdas

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -1598,6 +1598,32 @@ Object {
 }
 `;
 
+exports[`appsync config AppSync CloudWatch log group name is generated from API name and stage when logGroupName so configured 1`] = `
+Object {
+  "Properties": Object {
+    "LogGroupName": Object {
+      "Fn::Join": Array [
+        "/",
+        Array [
+          "/aws/appsync/apis",
+          Object {
+            "Fn::Join": Array [
+              "-",
+              Array [
+                "api",
+                "dev",
+              ],
+            ],
+          },
+        ],
+      ],
+    },
+    "RetentionInDays": 14,
+  },
+  "Type": "AWS::Logs::LogGroup",
+}
+`;
+
 exports[`appsync config Datasource generates HTTP authorization when authorizationConfig provided 1`] = `
 Object {
   "GraphQlDsHTTPSource": Object {

--- a/index.test.js
+++ b/index.test.js
@@ -118,6 +118,19 @@ describe('appsync config', () => {
     expect(resources.GraphQlApiLogGroup).toMatchSnapshot();
   });
 
+  test('AppSync CloudWatch log group name is generated from API name and stage when logGroupName so configured', () => {
+    serverless.service.provider.logRetentionInDays = 14;
+    const resources = plugin.getGraphQlApiEndpointResource({
+      ...config,
+      logConfig: {
+        level: 'ALL',
+        logGroupName: 'API_NAME'
+      },
+    });
+
+    expect(resources.GraphQlApiLogGroup).toMatchSnapshot();
+  });
+
   test('Schema is transformed into App Sync compatible syntax', () => {
     Object.assign(
       config,

--- a/index.test.js
+++ b/index.test.js
@@ -124,7 +124,7 @@ describe('appsync config', () => {
       ...config,
       logConfig: {
         level: 'ALL',
-        logGroupName: 'API_NAME'
+        logGroupName: 'API_NAME',
       },
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -416,7 +416,7 @@ class ServerlessAppsyncPlugin {
           Type: 'AWS::Logs::LogGroup',
           Properties: {
             LogGroupName: (config.logConfig.logGroupName && config.logConfig.logGroupName === 'API_NAME')
-              ? { 'Fn::Join': ['/', ['/aws/appsync/apis', { 'Fn::Join': ['-', [config.name, this.provider.getStage()]] } ]] }
+              ? { 'Fn::Join': ['/', ['/aws/appsync/apis', { 'Fn::Join': ['-', [config.name, this.provider.getStage()]] }]] }
               : { 'Fn::Join': ['/', ['/aws/appsync/apis', { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] }]] },
             RetentionInDays: this.serverless.service.provider.logRetentionInDays,
           },

--- a/src/index.js
+++ b/src/index.js
@@ -415,7 +415,9 @@ class ServerlessAppsyncPlugin {
         [`${logicalIdGraphQLApi}LogGroup`]: {
           Type: 'AWS::Logs::LogGroup',
           Properties: {
-            LogGroupName: { 'Fn::Join': ['/', ['/aws/appsync/apis', { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] }]] },
+            LogGroupName: (config.logConfig.logGroupName && config.logConfig.logGroupName === 'API_NAME')
+              ? { 'Fn::Join': ['/', ['/aws/appsync/apis', { 'Fn::Join': ['-', [config.name, this.provider.getStage()]] } ]] }
+              : { 'Fn::Join': ['/', ['/aws/appsync/apis', { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] }]] },
             RetentionInDays: this.serverless.service.provider.logRetentionInDays,
           },
         },


### PR DESCRIPTION
Extended `config.logConfig` with new property `logGroupName` that will, if configured to the value `API_NAME`, generate a log group name based on the API name + stage, e.g. "/aws/appsync/apis/api-dev".