### PR TITLE
fix: make hash description optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ apiKeys:
 
 You can also specify custom rules. For more info on how to define a rule, see the [Cfn documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-rule.html)
 
-Exemple:
+Example:
 
 ````yml
 wafConfig:
@@ -538,6 +538,19 @@ wafConfig:
           countryCodes:
             - US
 ````
+
+### Schema Comments
+In some cases you want to enable usage of old-style comments (#) in appSync. setting the ``allowHashDescription`` setting
+to true, will enable this.
+
+Example:
+```yml
+custom:
+  appSync:
+    name:  # defaults to api
+    allowHashDescription: true
+    # ... other settings
+```
 
 # Cli Usage
 

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -1769,6 +1769,32 @@ Object {
 }
 `;
 
+exports[`appsync config Schema allow hash comments when using allowHashDescription true in config 1`] = `
+Object {
+  "GraphQlSchema": Object {
+    "Properties": Object {
+      "ApiId": Object {
+        "Fn::GetAtt": Array [
+          "GraphQlApi",
+          "ApiId",
+        ],
+      },
+      "Definition": "
+                    type Thing implements One, Another {
+            hello: ID!
+          }
+          # test enum
+          enum Method {
+            DELETE
+            GET
+          }
+        ",
+    },
+    "Type": "AWS::AppSync::GraphQLSchema",
+  },
+}
+`;
+
 exports[`appsync config Schema is transformed into App Sync compatible syntax 1`] = `
 Object {
   "GraphQlSchema": Object {

--- a/index.test.js
+++ b/index.test.js
@@ -38,6 +38,7 @@ beforeEach(() => {
     mappingTemplatesLocation: 'mapping-templates',
     defaultMappingTemplates: {},
     substitutions: {},
+    allowHashDescription: false,
     xrayEnabled: false,
   };
 });

--- a/index.test.js
+++ b/index.test.js
@@ -139,6 +139,28 @@ describe('appsync config', () => {
     expect(schema).toMatchSnapshot();
   });
 
+  test('Schema allow hash comments when using allowHashDescription true in config', () => {
+    Object.assign(
+      config,
+      {
+        schema: `
+          """A valid schema"""
+          type Thing implements One & Another {
+            hello: ID!
+          }
+          # test enum
+          enum Method {
+            DELETE
+            GET
+          }
+        `,
+      },
+    );
+    config.allowHashDescription = true;
+    const schema = plugin.getGraphQLSchemaResource(config);
+    expect(schema).toMatchSnapshot();
+  });
+
   test('Datasource generates lambdaFunctionArn from functionName', () => {
     Object.assign(
       config,


### PR DESCRIPTION
#### Description

We being required to add documentation to our schema fields in AppSync but the comments are being removed. At
the moment AppSync only supports Old-style comments (#). 

This patch improves this PR ([#340](https://github.com/sid88in/serverless-appsync-plugin/pull/340)) adding the possibility to allow old-style comments (#) to be able to use what is supported in AppSync at least. until the release for the new spec.

I've been using this to release our schemas and is working, let me know if it can be improved. 

#### Changes

 1. Added new configuration field `allowHashDescription`
 2. Added new method to removeComments from schema
 3. Tests
 
 #### Verify
 
 1. use # in your schema to add comments
 2. set `allowHashDescription` to true in YAML
 3. publish.

 