### PR TITLE
feat: Support updating an existing AppSync API instead of creating a new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,9 @@ schema and resolvers from the code.
 If the existing API already contains data sources, those data sources will remain untouched unless they have the same
 names as the data sources in the code, in which case they will be replaced with the ones from the code.
 
+> **Note:** You should never set the apiId of an API that was previously deployed with the same serverless stack, otherwise, it would be deleted. That is because the resource would be removed from the stack.
+>
+> Only use the apiId parameter if you know what you are doing.
 
 ### Multiple APIs
 
@@ -338,7 +341,7 @@ custom:
       ...
 ```
 
-> Note: CloudFormation stack outputs and logical IDs will be changed from the defaults to api name prefixed. This allows you to differentiate the APIs on your stack if you want to work with multiple APIs.
+> **Note:** CloudFormation stack outputs and logical IDs will be changed from the defaults to api name prefixed. This allows you to differentiate the APIs on your stack if you want to work with multiple APIs.
 
 ### Pipeline Resolvers
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,50 @@ custom:
 
 > Be sure to replace all variables that have been commented out, or have an empty value.
 
+### Working with existing APIs
+
+If you already have an API created in AppSync through the UI or from a different CF stack
+and want to manage it via Serverless then the plugin can also support that.
+
+There is an optional *apiId* parameter that you can use to specify the ID of an existing AppSync API:
+```yaml
+custom:
+  appSync:
+    # ...
+    apiId: 1234abcd
+    # ...
+```
+Without *apiId* parameter the plugin will create a different endpoint with the same name alongside the original one.
+
+
+You can find the *apiId* value in the AppSync console, just open your existing AppSync API
+and go to Settings.
+
+In that case, the plugin will not attempt to create a new endpoint for you, instead, it will attach all newly configured resources to the
+existing endpoint.
+
+The following configuration options are only associated with the creation of a new AppSync endpoint
+and will be ignored if you provide *apiId* parameter:
+
+- name
+- authenticationType
+- caching
+- userPoolConfig
+- openIdConnectConfig
+- additionalAuthenticationProviders
+- logConfig
+- tags
+
+So later, if you wanted to change the name of the API, or add some tags, or change the logging configuration,
+ anything from the list above you would have to do that via a different method, for example from the UI.
+
+If the existing API already contains schema and resolvers those will be completely replaced by the new
+schema and resolvers from the code.
+
+If the existing API already contains data sources, those data sources will remain untouched unless they have the same
+names as the data sources in the code, in which case they will be replaced with the ones from the code.
+
+
 ### Multiple APIs
 
 If you have multiple APIs and do not want to split this up into another CloudFormation stack, simply change the `appSync` configuration property from an object into an array of objects:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ custom:
   appSync:
     name:  # defaults to api
     # apiKey # only required for update-appsync/delete-appsync
+    # apiId # if provided, will update the specified API.
     authenticationType: API_KEY or AWS_IAM or AMAZON_COGNITO_USER_POOLS or OPENID_CONNECT
     schema: # schema file or array of files to merge, defaults to schema.graphql
     # Caching options. Disabled by default

--- a/index.test.js
+++ b/index.test.js
@@ -262,6 +262,86 @@ describe('appsync config', () => {
     expect(dataSources).toMatchSnapshot();
   });
 
+  test('appsync API is not created when ApiId is used', () => {
+    Object.assign(
+      config,
+      {
+        apiId: 'testApiId',
+      },
+    );
+    const resources = plugin.getGraphQlApiEndpointResource(config);
+    expect(resources).toBeNull();
+  });
+
+  test('Existing ApiId is used for all resources if provided', () => {
+    const apiConfig = {
+      ...config,
+      apiId: 'testApiId',
+      authenticationType: 'API_KEY',
+      caching: {
+        behavior: 'FULL_REQUEST_CACHING',
+      },
+      schema: `
+          """A valid schema"""
+          type Thing implements One & Another {
+            hello: ID!
+          }
+          """A valid enum"""
+          enum Method {
+            DELETE # Delete something
+            GET # Get something
+          }
+        `,
+      dataSources: [
+        {
+          type: 'AMAZON_DYNAMODB',
+          name: 'DynamoDbSource',
+          config: {
+            tableName: 'myTable',
+            serviceRoleArn: 'arn:aws:iam::123456789012:role/service-role/myDynamoDbRole',
+            region: 'us-east-1',
+          },
+        },
+      ],
+      functionConfigurationsLocation: 'mapping-templates',
+      functionConfigurations: [
+        {
+          dataSource: 'ds',
+          name: 'pipeline',
+          request: 'request.vtl',
+          response: 'response.vtl',
+        },
+      ],
+      mappingTemplates: [
+        {
+          dataSource: 'ds',
+          type: 'Query',
+          field: 'field',
+          caching: true,
+        },
+      ],
+    };
+    const keyResources = plugin.getApiKeyResources(apiConfig);
+    const cachingResources = plugin.getApiCachingResource(apiConfig);
+    const schemaResources = plugin.getGraphQLSchemaResource(apiConfig);
+    const dataSourceResources = plugin.getDataSourceResources(apiConfig);
+    const functionConfigResources = plugin.getFunctionConfigurationResources(apiConfig);
+    const resolverResources = plugin.getResolverResources(apiConfig);
+    const outputs = plugin.getGraphQlApiOutputs(apiConfig);
+
+    expect(keyResources).toHaveProperty('GraphQlApiKeyDefault.Properties.ApiId', apiConfig.apiId);
+    expect(cachingResources).toHaveProperty('GraphQlCaching.Properties.ApiId', apiConfig.apiId);
+    expect(schemaResources).toHaveProperty('GraphQlSchema.Properties.ApiId', apiConfig.apiId);
+    expect(dataSourceResources).toHaveProperty('GraphQlDsDynamoDbSource.Properties.ApiId', apiConfig.apiId);
+    expect(functionConfigResources).toHaveProperty('GraphQlFunctionConfigurationpipeline.Properties.ApiId', apiConfig.apiId);
+    expect(resolverResources).toHaveProperty('GraphQlResolverQueryfield.Properties.ApiId', apiConfig.apiId);
+    expect(outputs).toEqual({
+      GraphQlApiId: {
+        Value: apiConfig.apiId,
+      },
+    });
+  });
+
   test('AMAZON_COGNITO_USER_POOLS config created', () => {
     const resources = plugin.getGraphQlApiEndpointResource({
       ...config,

--- a/src/index.js
+++ b/src/index.js
@@ -301,14 +301,6 @@ class ServerlessAppsyncPlugin {
     const outputs = this.serverless.service.provider.compiledCloudFormationTemplate.Outputs;
 
     config.forEach((apiConfig) => {
-      if (apiConfig.apiId) {
-        this.log('WARNING: serverless-appsync has been updated in a breaking way and your '
-          + 'service is configured using a reference to an existing apiKey in '
-          + '`custom.appSync` which is used in the legacy deploy scripts. This deploy will create '
-          + `new graphql resources and WILL NOT update your existing api. See ${MIGRATION_DOCS} for `
-          + 'more information', { color: 'orange' });
-      }
-
       Object.assign(resources, this.getGraphQlApiEndpointResource(apiConfig));
       Object.assign(resources, this.getApiKeyResources(apiConfig));
       Object.assign(resources, this.getApiCachingResource(apiConfig));
@@ -372,6 +364,10 @@ class ServerlessAppsyncPlugin {
   }
 
   getGraphQlApiEndpointResource(config) {
+    if (config.apiId) {
+      this.log(`Updating an existing API endpoint: ${config.apiId}`);
+      return null;
+    }
     const logicalIdGraphQLApi = this.getLogicalId(config, RESOURCE_API);
     const logicalIdCloudWatchLogsRole = this.getLogicalId(
       config,
@@ -496,7 +492,7 @@ class ServerlessAppsyncPlugin {
         acc[logicalIdApiKey] = {
           Type: 'AWS::AppSync::ApiKey',
           Properties: {
-            ApiId: { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
+            ApiId: config.apiId || { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
             Description: description || name,
             Expires: expires.unix(),
             ApiKeyId: apiKeyId,
@@ -518,7 +514,7 @@ class ServerlessAppsyncPlugin {
           Type: 'AWS::AppSync::ApiCache',
           Properties: {
             ApiCachingBehavior: config.caching.behavior,
-            ApiId: { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
+            ApiId: config.apiId || { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
             AtRestEncryptionEnabled: config.caching.atRestEncryption || false,
             TransitEncryptionEnabled: config.caching.transitEncryption || false,
             Ttl: config.caching.ttl || 3600,
@@ -817,7 +813,7 @@ class ServerlessAppsyncPlugin {
       const resource = {
         Type: 'AWS::AppSync::DataSource',
         Properties: {
-          ApiId: { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
+          ApiId: config.apiId || { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
           Name: ds.name,
           Description: ds.description,
           Type: ds.type,
@@ -915,7 +911,7 @@ class ServerlessAppsyncPlugin {
         Type: 'AWS::AppSync::GraphQLSchema',
         Properties: {
           Definition: appSyncSafeSchema,
-          ApiId: { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
+          ApiId: config.apiId || { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
         },
       },
     };
@@ -936,7 +932,7 @@ class ServerlessAppsyncPlugin {
       );
 
       const Properties = {
-        ApiId: { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
+        ApiId: config.apiId || { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
         Name: this.getCfnName(tpl.name),
         DataSourceName: { 'Fn::GetAtt': [logicalIdDataSource, 'Name'] },
         Description: tpl.description,
@@ -996,7 +992,7 @@ class ServerlessAppsyncPlugin {
       );
 
       let Properties = {
-        ApiId: { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
+        ApiId: config.apiId || { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
         TypeName: tpl.type,
         FieldName: tpl.field,
       };
@@ -1376,14 +1372,18 @@ class ServerlessAppsyncPlugin {
     const logicalIdGraphQLApi = this.getLogicalId(config, RESOURCE_API);
     const logicalIdGraphQLApiUrlOutput = this.getLogicalId(config, RESOURCE_URL);
     const logicalIdGraphQLApiIdOutput = this.getLogicalId(config, RESOURCE_API_ID);
-    return {
-      [logicalIdGraphQLApiUrlOutput]: {
-        Value: { 'Fn::GetAtt': [logicalIdGraphQLApi, 'GraphQLUrl'] },
-      },
+    const results = {
       [logicalIdGraphQLApiIdOutput]: {
-        Value: { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
+        Value: config.apiId || { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
       },
     };
+    // output the URL if we are not updating a specific API endpoint
+    if (!config.apiId) {
+      results[[logicalIdGraphQLApiUrlOutput]] = {
+        Value: { 'Fn::GetAtt': [logicalIdGraphQLApi, 'GraphQLUrl'] },
+      };
+    }
+    return results;
   }
 
   getApiKeyOutputs(config) {


### PR DESCRIPTION
At the moment existing AppSync apis are not supported by the plugin. If there is an existing API in AppSync the plugin will create another one with the same name. 

The proposal is to add back the support of an optional apiId parameter to the Serverless config file. If it is provided then do not create a new AppSync API endpoint but update the existing endpoint instead. This will just update the resources of the existing API and leave the log groups, API URL, API id, authentication provider and the rest of the main stuff unmodified (The auto-generated API URL will not be modified which is important if it is used by some clients and there is no Route53/CloudFront distribution configured).
