### PR TITLE
Make authentication type optional when api id is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,9 @@ and will be ignored if you provide *apiId* parameter:
 - additionalAuthenticationProviders
 - logConfig
 - tags
+- xrayEnabled
+- apiKeys
+- wafConfig
 
 So later, if you wanted to change the name of the API, or add some tags, or change the logging configuration,
  anything from the list above you would have to do that via a different method, for example from the UI.

--- a/README.md
+++ b/README.md
@@ -292,7 +292,6 @@ and will be ignored if you provide *apiId* parameter:
 
 - name
 - authenticationType
-- caching
 - userPoolConfig
 - openIdConnectConfig
 - additionalAuthenticationProviders

--- a/__snapshots__/get-config.test.js.snap
+++ b/__snapshots__/get-config.test.js.snap
@@ -201,6 +201,121 @@ schema {
 ]
 `;
 
+exports[`authenticationType can be missing when apiId is provided 1`] = `
+Array [
+  Object {
+    "additionalAuthenticationProviders": Array [],
+    "apiId": "testApiId",
+    "authenticationType": undefined,
+    "dataSources": Array [],
+    "defaultMappingTemplates": Object {},
+    "functionConfigurations": Array [],
+    "functionConfigurationsLocation": "mapping-templates",
+    "isSingleConfig": true,
+    "mappingTemplates": Array [],
+    "mappingTemplatesLocation": "mapping-templates",
+    "name": "api",
+    "region": "us-east-1",
+    "schema": "type Mutation {
+	# Create a tweet for a user
+	# consumer keys and tokens are not required for dynamo integration
+	createTweet(
+		tweet: String!,
+		consumer_key: String,
+		consumer_secret: String,
+		access_token_key: String,
+		access_token_secret: String,
+		created_at: String!
+	): Tweet!
+
+	# Delete User Tweet
+	deleteTweet(
+	    tweet_id: String!,
+	    consumer_key: String,
+        consumer_secret: String,
+        access_token_key: String,
+        access_token_secret: String
+    ): Tweet!
+
+	# Retweet existing Tweet
+	reTweet(
+	    tweet_id: String!,
+	    consumer_key: String,
+        consumer_secret: String,
+        access_token_key: String,
+        access_token_secret: String
+    ): Tweet!
+
+	# Update existing Tweet
+	updateTweet(tweet_id: String!, tweet: String!): Tweet!
+
+    # Create user info is available in dynamo integration
+	updateUserInfo(
+		location: String!,
+		description: String!,
+		name: String!,
+		followers_count: Int!,
+		friends_count: Int!,
+		favourites_count: Int!,
+		followers: [String!]!
+	): User!
+}
+
+type Query {
+	meInfo(consumer_key: String, consumer_secret: String): User!
+	getUserInfo(handle: String!, consumer_key: String, consumer_secret: String): User!
+
+	# search functionality is available in elasticsearch integration
+	searchAllTweetsByKeyword(keyword: String!): TweetConnection
+}
+
+type Subscription {
+	addTweet: Tweet
+		@aws_subscribe(mutations: [\\"createTweet\\"])
+}
+
+type Tweet {
+	tweet_id: String!
+	tweet: String!
+	retweeted: Boolean
+	retweet_count: Int
+	favorited: Boolean
+	created_at: String!
+}
+
+type TweetConnection {
+	items: [Tweet!]!
+	nextToken: String
+}
+
+type User {
+	name: String!
+	handle: String!
+	location: String!
+	description: String!
+	followers_count: Int!
+	friends_count: Int!
+	favourites_count: Int!
+	followers: [String!]!
+	topTweet: Tweet
+	tweets(limit: Int!, nextToken: String): TweetConnection
+
+	# search functionality is available in elasticsearch integration
+    searchTweetsByKeyword(keyword: String!): TweetConnection
+}
+
+schema {
+	query: Query
+	mutation: Mutation
+	subscription: Subscription
+}
+",
+    "substitutions": Object {},
+    "xrayEnabled": false,
+  },
+]
+`;
+
 exports[`authenticationType is missing 1`] = `"appSync property \`authenticationType\` is missing or invalid."`;
 
 exports[`authenticationType is missing 2`] = `"appSync property \`authenticationType\` is missing or invalid."`;

--- a/__snapshots__/get-config.test.js.snap
+++ b/__snapshots__/get-config.test.js.snap
@@ -364,97 +364,70 @@ Array [
     "name": "api",
     "region": "us-east-1",
     "schema": "type Mutation {
-	# Create a tweet for a user
-	# consumer keys and tokens are not required for dynamo integration
-	createTweet(
-		tweet: String!,
-		consumer_key: String,
-		consumer_secret: String,
-		access_token_key: String,
-		access_token_secret: String,
-		created_at: String!
-	): Tweet!
-
-	# Delete User Tweet
-	deleteTweet(
-	    tweet_id: String!,
-	    consumer_key: String,
-        consumer_secret: String,
-        access_token_key: String,
-        access_token_secret: String
-    ): Tweet!
-
-	# Retweet existing Tweet
-	reTweet(
-	    tweet_id: String!,
-	    consumer_key: String,
-        consumer_secret: String,
-        access_token_key: String,
-        access_token_secret: String
-    ): Tweet!
-
-	# Update existing Tweet
-	updateTweet(tweet_id: String!, tweet: String!): Tweet!
-
-    # Create user info is available in dynamo integration
-	updateUserInfo(
-		location: String!,
-		description: String!,
-		name: String!,
-		followers_count: Int!,
-		friends_count: Int!,
-		favourites_count: Int!,
-		followers: [String!]!
-	): User!
+  
+  # Create a tweet for a user
+  # consumer keys and tokens are not required for dynamo integration
+  createTweet(tweet: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String, created_at: String!): Tweet!
+  
+  # Delete User Tweet
+  deleteTweet(tweet_id: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String): Tweet!
+  
+  # Retweet existing Tweet
+  reTweet(tweet_id: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String): Tweet!
+  
+  # Update existing Tweet
+  updateTweet(tweet_id: String!, tweet: String!): Tweet!
+  
+  # Create user info is available in dynamo integration
+  updateUserInfo(location: String!, description: String!, name: String!, followers_count: Int!, friends_count: Int!, favourites_count: Int!, followers: [String!]!): User!
 }
 
 type Query {
-	meInfo(consumer_key: String, consumer_secret: String): User!
-	getUserInfo(handle: String!, consumer_key: String, consumer_secret: String): User!
-
-	# search functionality is available in elasticsearch integration
-	searchAllTweetsByKeyword(keyword: String!): TweetConnection
+  meInfo(consumer_key: String, consumer_secret: String): User!
+  getUserInfo(handle: String!, consumer_key: String, consumer_secret: String): User!
+  
+  # search functionality is available in elasticsearch integration
+  searchAllTweetsByKeyword(keyword: String!): TweetConnection
 }
 
 type Subscription {
-	addTweet: Tweet
-		@aws_subscribe(mutations: [\\"createTweet\\"])
+  addTweet: Tweet @aws_subscribe(mutations: [\\"createTweet\\"])
 }
 
 type Tweet {
-	tweet_id: String!
-	tweet: String!
-	retweeted: Boolean
-	retweet_count: Int
-	favorited: Boolean
-	created_at: String!
+  tweet_id: String!
+  tweet: String!
+  retweeted: Boolean
+  retweet_count: Int
+  favorited: Boolean
+  created_at: String!
 }
 
 type TweetConnection {
-	items: [Tweet!]!
-	nextToken: String
+  items: [Tweet!]!
+  nextToken: String
 }
 
 type User {
-	name: String!
-	handle: String!
-	location: String!
-	description: String!
-	followers_count: Int!
-	friends_count: Int!
-	favourites_count: Int!
-	followers: [String!]!
-	topTweet: Tweet
-	tweets(limit: Int!, nextToken: String): TweetConnection
-
-	# search functionality is available in elasticsearch integration
-    searchTweetsByKeyword(keyword: String!): TweetConnection
+  name: String!
+  handle: String!
+  location: String!
+  description: String!
+  followers_count: Int!
+  friends_count: Int!
+  favourites_count: Int!
+  followers: [String!]!
+  topTweet: Tweet
+  tweets(limit: Int!, nextToken: String): TweetConnection
+  
+  # search functionality is available in elasticsearch integration
+  searchTweetsByKeyword(keyword: String!): TweetConnection
 }
 
 schema {
-	query: Query
-	mutation: Mutation
-	subscription: Subscription
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
 }
 ",
     "substitutions": Object {},

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -1598,6 +1598,78 @@ Object {
 }
 `;
 
+exports[`appsync config AppSync settings are not updated when ApiId is provided 1`] = `
+Object {
+  "GraphQlDsDynamoDbSource": Object {
+    "Properties": Object {
+      "ApiId": "testApiId",
+      "Description": undefined,
+      "DynamoDBConfig": Object {
+        "AwsRegion": "us-east-1",
+        "TableName": "myTable",
+        "UseCallerCredentials": false,
+        "Versioned": false,
+      },
+      "Name": "DynamoDbSource",
+      "ServiceRoleArn": "arn:aws:iam::123456789012:role/service-role/myDynamoDbRole",
+      "Type": "AMAZON_DYNAMODB",
+    },
+    "Type": "AWS::AppSync::DataSource",
+  },
+  "GraphQlFunctionConfigurationpipeline": Object {
+    "Properties": Object {
+      "ApiId": "testApiId",
+      "DataSourceName": Object {
+        "Fn::GetAtt": Array [
+          "GraphQlDsds",
+          "Name",
+        ],
+      },
+      "Description": undefined,
+      "FunctionVersion": "2018-05-29",
+      "Name": "pipeline",
+      "RequestMappingTemplate": "Content: mapping-templates/request.vtl",
+      "ResponseMappingTemplate": "Content: mapping-templates/response.vtl",
+    },
+    "Type": "AWS::AppSync::FunctionConfiguration",
+  },
+  "GraphQlResolverQueryfield": Object {
+    "DependsOn": "GraphQlSchema",
+    "Properties": Object {
+      "ApiId": "testApiId",
+      "CachingConfig": Object {
+        "Ttl": 3600,
+      },
+      "DataSourceName": Object {
+        "Fn::GetAtt": Array [
+          "GraphQlDsds",
+          "Name",
+        ],
+      },
+      "FieldName": "field",
+      "Kind": "UNIT",
+      "RequestMappingTemplate": "Content: mapping-templates/Query.field.request.vtl",
+      "ResponseMappingTemplate": "Content: mapping-templates/Query.field.response.vtl",
+      "TypeName": "Query",
+    },
+    "Type": "AWS::AppSync::Resolver",
+  },
+  "GraphQlSchema": Object {
+    "Properties": Object {
+      "ApiId": "testApiId",
+      "Definition": "
+                    type Thing implements One, Another {
+            hello: ID!
+          }
+                    enum Method {
+            DELETE             GET           }
+        ",
+    },
+    "Type": "AWS::AppSync::GraphQLSchema",
+  },
+}
+`;
+
 exports[`appsync config Datasource generates HTTP authorization when authorizationConfig provided 1`] = `
 Object {
   "GraphQlDsHTTPSource": Object {
@@ -1735,6 +1807,75 @@ Object {
       "Expires": 1639065600,
     },
     "Type": "AWS::AppSync::ApiKey",
+  },
+}
+`;
+
+exports[`appsync config Existing ApiId is used for all resources if provided 1`] = `
+Object {
+  "GraphQlDsDynamoDbSource": Object {
+    "Properties": Object {
+      "ApiId": "testApiId",
+      "Description": undefined,
+      "DynamoDBConfig": Object {
+        "AwsRegion": "us-east-1",
+        "TableName": "myTable",
+        "UseCallerCredentials": false,
+        "Versioned": false,
+      },
+      "Name": "DynamoDbSource",
+      "ServiceRoleArn": "arn:aws:iam::123456789012:role/service-role/myDynamoDbRole",
+      "Type": "AMAZON_DYNAMODB",
+    },
+    "Type": "AWS::AppSync::DataSource",
+  },
+  "GraphQlFunctionConfigurationpipeline": Object {
+    "Properties": Object {
+      "ApiId": "testApiId",
+      "DataSourceName": Object {
+        "Fn::GetAtt": Array [
+          "GraphQlDsds",
+          "Name",
+        ],
+      },
+      "Description": undefined,
+      "FunctionVersion": "2018-05-29",
+      "Name": "pipeline",
+      "RequestMappingTemplate": "Content: mapping-templates/request.vtl",
+      "ResponseMappingTemplate": "Content: mapping-templates/response.vtl",
+    },
+    "Type": "AWS::AppSync::FunctionConfiguration",
+  },
+  "GraphQlResolverQueryfield": Object {
+    "DependsOn": "GraphQlSchema",
+    "Properties": Object {
+      "ApiId": "testApiId",
+      "DataSourceName": Object {
+        "Fn::GetAtt": Array [
+          "GraphQlDsds",
+          "Name",
+        ],
+      },
+      "FieldName": "field",
+      "Kind": "UNIT",
+      "RequestMappingTemplate": "Content: mapping-templates/Query.field.request.vtl",
+      "ResponseMappingTemplate": "Content: mapping-templates/Query.field.response.vtl",
+      "TypeName": "Query",
+    },
+    "Type": "AWS::AppSync::Resolver",
+  },
+  "GraphQlSchema": Object {
+    "Properties": Object {
+      "ApiId": "testApiId",
+      "Definition": "
+                    type Thing implements One, Another {
+            hello: ID!
+          }
+                    enum Method {
+            DELETE             GET           }
+        ",
+    },
+    "Type": "AWS::AppSync::GraphQLSchema",
   },
 }
 `;

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -1600,6 +1600,17 @@ Object {
 
 exports[`appsync config AppSync settings are not updated when ApiId is provided 1`] = `
 Object {
+  "GraphQlCaching": Object {
+    "Properties": Object {
+      "ApiCachingBehavior": "FULL_REQUEST_CACHING",
+      "ApiId": "testApiId",
+      "AtRestEncryptionEnabled": false,
+      "TransitEncryptionEnabled": false,
+      "Ttl": 3600,
+      "Type": "T2_SMALL",
+    },
+    "Type": "AWS::AppSync::ApiCache",
+  },
   "GraphQlDsDynamoDbSource": Object {
     "Properties": Object {
       "ApiId": "testApiId",

--- a/get-config.test.js
+++ b/get-config.test.js
@@ -19,6 +19,16 @@ test('authenticationType is missing', () => {
   expect(run).toThrowErrorMatchingSnapshot();
 });
 
+test('authenticationType can be missing when apiId is provided', () => {
+  expect(getConfig(
+    {
+      apiId: 'testApiId',
+    },
+    { region: 'us-east-1' },
+    servicePath,
+  )).toMatchSnapshot();
+});
+
 test('returns valid config', () => {
   expect(getConfig(
     {
@@ -108,3 +118,4 @@ test('Schema as array', () => {
     servicePath,
   )).toMatchSnapshot();
 });
+

--- a/src/get-config.js
+++ b/src/get-config.js
@@ -30,7 +30,8 @@ const getConfig = (config, provider, servicePath) => {
       config.authenticationType === 'API_KEY' ||
       config.authenticationType === 'AWS_IAM' ||
       config.authenticationType === 'AMAZON_COGNITO_USER_POOLS' ||
-      config.authenticationType === 'OPENID_CONNECT'
+      config.authenticationType === 'OPENID_CONNECT' ||
+      config.apiId
     )
   ) {
     throw new Error('appSync property `authenticationType` is missing or invalid.');

--- a/src/index.js
+++ b/src/index.js
@@ -301,19 +301,41 @@ class ServerlessAppsyncPlugin {
     const outputs = this.serverless.service.provider.compiledCloudFormationTemplate.Outputs;
 
     config.forEach((apiConfig) => {
+      this.addResource(resources, outputs, apiConfig);
+    });
+  }
+
+  addResource(resources, outputs, apiConfig) {
+    if (apiConfig.apiId) {
+      this.log(`
+          Updating an existing API endpoint: ${apiConfig.apiId}.
+          The following configuration options are ignored:
+            - name
+            - authenticationType
+            - caching
+            - userPoolConfig
+            - openIdConnectConfig
+            - additionalAuthenticationProviders
+            - logConfig
+            - tags
+            - xrayEnabled
+            - apiKeys
+            - wafConfig
+        `);
+    } else {
       Object.assign(resources, this.getGraphQlApiEndpointResource(apiConfig));
       Object.assign(resources, this.getApiKeyResources(apiConfig));
       Object.assign(resources, this.getApiCachingResource(apiConfig));
-      Object.assign(resources, this.getGraphQLSchemaResource(apiConfig));
       Object.assign(resources, this.getCloudWatchLogsRole(apiConfig));
-      Object.assign(resources, this.getDataSourceIamRolesResouces(apiConfig));
-      Object.assign(resources, this.getDataSourceResources(apiConfig));
-      Object.assign(resources, this.getFunctionConfigurationResources(apiConfig));
-      Object.assign(resources, this.getResolverResources(apiConfig));
       Object.assign(resources, this.getWafResources(apiConfig));
-      Object.assign(outputs, this.getGraphQlApiOutputs(apiConfig));
       Object.assign(outputs, this.getApiKeyOutputs(apiConfig));
-    });
+    }
+    Object.assign(resources, this.getGraphQLSchemaResource(apiConfig));
+    Object.assign(resources, this.getDataSourceIamRolesResouces(apiConfig));
+    Object.assign(resources, this.getDataSourceResources(apiConfig));
+    Object.assign(resources, this.getFunctionConfigurationResources(apiConfig));
+    Object.assign(resources, this.getResolverResources(apiConfig));
+    Object.assign(outputs, this.getGraphQlApiOutputs(apiConfig));
   }
 
   getUserPoolConfig(provider, region) {
@@ -364,10 +386,6 @@ class ServerlessAppsyncPlugin {
   }
 
   getGraphQlApiEndpointResource(config) {
-    if (config.apiId) {
-      this.log(`Updating an existing API endpoint: ${config.apiId}`);
-      return null;
-    }
     const logicalIdGraphQLApi = this.getLogicalId(config, RESOURCE_API);
     const logicalIdCloudWatchLogsRole = this.getLogicalId(
       config,
@@ -492,7 +510,7 @@ class ServerlessAppsyncPlugin {
         acc[logicalIdApiKey] = {
           Type: 'AWS::AppSync::ApiKey',
           Properties: {
-            ApiId: config.apiId || { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
+            ApiId: { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
             Description: description || name,
             Expires: expires.unix(),
             ApiKeyId: apiKeyId,
@@ -514,7 +532,7 @@ class ServerlessAppsyncPlugin {
           Type: 'AWS::AppSync::ApiCache',
           Properties: {
             ApiCachingBehavior: config.caching.behavior,
-            ApiId: config.apiId || { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
+            ApiId: { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
             AtRestEncryptionEnabled: config.caching.atRestEncryption || false,
             TransitEncryptionEnabled: config.caching.transitEncryption || false,
             Ttl: config.caching.ttl || 3600,

--- a/src/index.js
+++ b/src/index.js
@@ -312,7 +312,6 @@ class ServerlessAppsyncPlugin {
           The following configuration options are ignored:
             - name
             - authenticationType
-            - caching
             - userPoolConfig
             - openIdConnectConfig
             - additionalAuthenticationProviders
@@ -325,11 +324,11 @@ class ServerlessAppsyncPlugin {
     } else {
       Object.assign(resources, this.getGraphQlApiEndpointResource(apiConfig));
       Object.assign(resources, this.getApiKeyResources(apiConfig));
-      Object.assign(resources, this.getApiCachingResource(apiConfig));
       Object.assign(resources, this.getCloudWatchLogsRole(apiConfig));
       Object.assign(resources, this.getWafResources(apiConfig));
       Object.assign(outputs, this.getApiKeyOutputs(apiConfig));
     }
+    Object.assign(resources, this.getApiCachingResource(apiConfig));
     Object.assign(resources, this.getGraphQLSchemaResource(apiConfig));
     Object.assign(resources, this.getDataSourceIamRolesResouces(apiConfig));
     Object.assign(resources, this.getDataSourceResources(apiConfig));
@@ -532,7 +531,7 @@ class ServerlessAppsyncPlugin {
           Type: 'AWS::AppSync::ApiCache',
           Properties: {
             ApiCachingBehavior: config.caching.behavior,
-            ApiId: { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
+            ApiId: config.apiId || { 'Fn::GetAtt': [logicalIdGraphQLApi, 'ApiId'] },
             AtRestEncryptionEnabled: config.caching.atRestEncryption || false,
             TransitEncryptionEnabled: config.caching.transitEncryption || false,
             Ttl: config.caching.ttl || 3600,


### PR DESCRIPTION
Made authenticationType attribute optional if user provided the apiId attribute, since it is not used anyway.
It will allow users to create cleaner configs if all they want is to update resources in an existing AppSync API.

Also added 3 more ignored attributes to the README.
And added a log highlighting the same information if user provided an API ID.

Moved the check for the appId attribute to addResources method to make it easier to see from the code where it is used and which attributes are ignored. The ignored attributes are all attributes that modify AppSync API settings.

Updated the unit tests to make sure that the ignored resources are actually ignored.
Tested the creation of a new API and the updates to an existing API.

The attributes are ignored (instead of throwing an exception) due to the backwards compatibility with the previous version, where user could provide the apiId and call the delete operation without removing existing attributes. Otherwise I would add an exception if any of them was provided together with apiId.