### PR TITLE
feat: Support glob pattern and absolute path for schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ custom:
     # apiKey # only required for update-appsync/delete-appsync
     # apiId # if provided, will update the specified API.
     authenticationType: API_KEY or AWS_IAM or AMAZON_COGNITO_USER_POOLS or OPENID_CONNECT
-    schema: # schema file or array of files to merge, defaults to schema.graphql
+    schema: # schema file or array of files to merge, defaults to schema.graphql (glob pattern is acceptable)
     # Caching options. Disabled by default
     # read more at https://aws.amazon.com/blogs/mobile/appsync-caching-transactions/
     # and https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-apicache.html

--- a/__snapshots__/get-config.test.js.snap
+++ b/__snapshots__/get-config.test.js.snap
@@ -1,6 +1,180 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Schema as absolute path 1`] = `
+Array [
+  Object {
+    "additionalAuthenticationProviders": Array [],
+    "authenticationType": "AWS_IAM",
+    "dataSources": Array [],
+    "defaultMappingTemplates": Object {},
+    "functionConfigurations": Array [],
+    "functionConfigurationsLocation": "mapping-templates",
+    "isSingleConfig": true,
+    "mappingTemplates": Array [],
+    "mappingTemplatesLocation": "mapping-templates",
+    "name": "api",
+    "region": "us-east-1",
+    "schema": "type Mutation {
+  
+  # Create a tweet for a user
+  # consumer keys and tokens are not required for dynamo integration
+  createTweet(tweet: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String, created_at: String!): Tweet!
+  
+  # Delete User Tweet
+  deleteTweet(tweet_id: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String): Tweet!
+  
+  # Retweet existing Tweet
+  reTweet(tweet_id: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String): Tweet!
+  
+  # Update existing Tweet
+  updateTweet(tweet_id: String!, tweet: String!): Tweet!
+  
+  # Create user info is available in dynamo integration
+  updateUserInfo(location: String!, description: String!, name: String!, followers_count: Int!, friends_count: Int!, favourites_count: Int!, followers: [String!]!): User!
+}
+
+type Query {
+  meInfo(consumer_key: String, consumer_secret: String): User!
+  getUserInfo(handle: String!, consumer_key: String, consumer_secret: String): User!
+  
+  # search functionality is available in elasticsearch integration
+  searchAllTweetsByKeyword(keyword: String!): TweetConnection
+}
+
+type Subscription {
+  addTweet: Tweet @aws_subscribe(mutations: [\\"createTweet\\"])
+}
+
+type Tweet {
+  tweet_id: String!
+  tweet: String!
+  retweeted: Boolean
+  retweet_count: Int
+  favorited: Boolean
+  created_at: String!
+}
+
+type TweetConnection {
+  items: [Tweet!]!
+  nextToken: String
+}
+
+type User {
+  name: String!
+  handle: String!
+  location: String!
+  description: String!
+  followers_count: Int!
+  friends_count: Int!
+  favourites_count: Int!
+  followers: [String!]!
+  topTweet: Tweet
+  tweets(limit: Int!, nextToken: String): TweetConnection
+  
+  # search functionality is available in elasticsearch integration
+  searchTweetsByKeyword(keyword: String!): TweetConnection
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+",
+    "substitutions": Object {},
+    "xrayEnabled": false,
+  },
+]
+`;
+
 exports[`Schema as array 1`] = `
+Array [
+  Object {
+    "additionalAuthenticationProviders": Array [],
+    "authenticationType": "AWS_IAM",
+    "dataSources": Array [],
+    "defaultMappingTemplates": Object {},
+    "functionConfigurations": Array [],
+    "functionConfigurationsLocation": "mapping-templates",
+    "isSingleConfig": true,
+    "mappingTemplates": Array [],
+    "mappingTemplatesLocation": "mapping-templates",
+    "name": "api",
+    "region": "us-east-1",
+    "schema": "type Mutation {
+  
+  # Create a tweet for a user
+  # consumer keys and tokens are not required for dynamo integration
+  createTweet(tweet: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String, created_at: String!): Tweet!
+  
+  # Delete User Tweet
+  deleteTweet(tweet_id: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String): Tweet!
+  
+  # Retweet existing Tweet
+  reTweet(tweet_id: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String): Tweet!
+  
+  # Update existing Tweet
+  updateTweet(tweet_id: String!, tweet: String!): Tweet!
+  
+  # Create user info is available in dynamo integration
+  updateUserInfo(location: String!, description: String!, name: String!, followers_count: Int!, friends_count: Int!, favourites_count: Int!, followers: [String!]!): User!
+}
+
+type Query {
+  
+  # search functionality is available in elasticsearch integration
+  searchAllTweetsByKeyword(keyword: String!): TweetConnection
+  getUserInfo(handle: String!, consumer_key: String, consumer_secret: String): User!
+  meInfo(consumer_key: String, consumer_secret: String): User!
+}
+
+type Subscription {
+  addTweet: Tweet @aws_subscribe(mutations: [\\"createTweet\\"])
+}
+
+type Tweet {
+  tweet_id: String!
+  tweet: String!
+  retweeted: Boolean
+  retweet_count: Int
+  favorited: Boolean
+  created_at: String!
+}
+
+type TweetConnection {
+  items: [Tweet!]!
+  nextToken: String
+}
+
+type User {
+  name: String!
+  handle: String!
+  location: String!
+  description: String!
+  followers_count: Int!
+  friends_count: Int!
+  favourites_count: Int!
+  followers: [String!]!
+  topTweet: Tweet
+  tweets(limit: Int!, nextToken: String): TweetConnection
+  
+  # search functionality is available in elasticsearch integration
+  searchTweetsByKeyword(keyword: String!): TweetConnection
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+",
+    "substitutions": Object {},
+    "xrayEnabled": false,
+  },
+]
+`;
+
+exports[`Schema as glob pattern 1`] = `
 Array [
   Object {
     "additionalAuthenticationProviders": Array [],
@@ -102,97 +276,70 @@ Array [
     "name": "api",
     "region": "us-east-1",
     "schema": "type Mutation {
-	# Create a tweet for a user
-	# consumer keys and tokens are not required for dynamo integration
-	createTweet(
-		tweet: String!,
-		consumer_key: String,
-		consumer_secret: String,
-		access_token_key: String,
-		access_token_secret: String,
-		created_at: String!
-	): Tweet!
-
-	# Delete User Tweet
-	deleteTweet(
-	    tweet_id: String!,
-	    consumer_key: String,
-        consumer_secret: String,
-        access_token_key: String,
-        access_token_secret: String
-    ): Tweet!
-
-	# Retweet existing Tweet
-	reTweet(
-	    tweet_id: String!,
-	    consumer_key: String,
-        consumer_secret: String,
-        access_token_key: String,
-        access_token_secret: String
-    ): Tweet!
-
-	# Update existing Tweet
-	updateTweet(tweet_id: String!, tweet: String!): Tweet!
-
-    # Create user info is available in dynamo integration
-	updateUserInfo(
-		location: String!,
-		description: String!,
-		name: String!,
-		followers_count: Int!,
-		friends_count: Int!,
-		favourites_count: Int!,
-		followers: [String!]!
-	): User!
+  
+  # Create a tweet for a user
+  # consumer keys and tokens are not required for dynamo integration
+  createTweet(tweet: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String, created_at: String!): Tweet!
+  
+  # Delete User Tweet
+  deleteTweet(tweet_id: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String): Tweet!
+  
+  # Retweet existing Tweet
+  reTweet(tweet_id: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String): Tweet!
+  
+  # Update existing Tweet
+  updateTweet(tweet_id: String!, tweet: String!): Tweet!
+  
+  # Create user info is available in dynamo integration
+  updateUserInfo(location: String!, description: String!, name: String!, followers_count: Int!, friends_count: Int!, favourites_count: Int!, followers: [String!]!): User!
 }
 
 type Query {
-	meInfo(consumer_key: String, consumer_secret: String): User!
-	getUserInfo(handle: String!, consumer_key: String, consumer_secret: String): User!
-
-	# search functionality is available in elasticsearch integration
-	searchAllTweetsByKeyword(keyword: String!): TweetConnection
+  meInfo(consumer_key: String, consumer_secret: String): User!
+  getUserInfo(handle: String!, consumer_key: String, consumer_secret: String): User!
+  
+  # search functionality is available in elasticsearch integration
+  searchAllTweetsByKeyword(keyword: String!): TweetConnection
 }
 
 type Subscription {
-	addTweet: Tweet
-		@aws_subscribe(mutations: [\\"createTweet\\"])
+  addTweet: Tweet @aws_subscribe(mutations: [\\"createTweet\\"])
 }
 
 type Tweet {
-	tweet_id: String!
-	tweet: String!
-	retweeted: Boolean
-	retweet_count: Int
-	favorited: Boolean
-	created_at: String!
+  tweet_id: String!
+  tweet: String!
+  retweeted: Boolean
+  retweet_count: Int
+  favorited: Boolean
+  created_at: String!
 }
 
 type TweetConnection {
-	items: [Tweet!]!
-	nextToken: String
+  items: [Tweet!]!
+  nextToken: String
 }
 
 type User {
-	name: String!
-	handle: String!
-	location: String!
-	description: String!
-	followers_count: Int!
-	friends_count: Int!
-	favourites_count: Int!
-	followers: [String!]!
-	topTweet: Tweet
-	tweets(limit: Int!, nextToken: String): TweetConnection
-
-	# search functionality is available in elasticsearch integration
-    searchTweetsByKeyword(keyword: String!): TweetConnection
+  name: String!
+  handle: String!
+  location: String!
+  description: String!
+  followers_count: Int!
+  friends_count: Int!
+  favourites_count: Int!
+  followers: [String!]!
+  topTweet: Tweet
+  tweets(limit: Int!, nextToken: String): TweetConnection
+  
+  # search functionality is available in elasticsearch integration
+  searchTweetsByKeyword(keyword: String!): TweetConnection
 }
 
 schema {
-	query: Query
-	mutation: Mutation
-	subscription: Subscription
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
 }
 ",
     "substitutions": Object {},
@@ -229,97 +376,70 @@ Array [
     "name": "api",
     "region": "us-east-1",
     "schema": "type Mutation {
-	# Create a tweet for a user
-	# consumer keys and tokens are not required for dynamo integration
-	createTweet(
-		tweet: String!,
-		consumer_key: String,
-		consumer_secret: String,
-		access_token_key: String,
-		access_token_secret: String,
-		created_at: String!
-	): Tweet!
-
-	# Delete User Tweet
-	deleteTweet(
-	    tweet_id: String!,
-	    consumer_key: String,
-        consumer_secret: String,
-        access_token_key: String,
-        access_token_secret: String
-    ): Tweet!
-
-	# Retweet existing Tweet
-	reTweet(
-	    tweet_id: String!,
-	    consumer_key: String,
-        consumer_secret: String,
-        access_token_key: String,
-        access_token_secret: String
-    ): Tweet!
-
-	# Update existing Tweet
-	updateTweet(tweet_id: String!, tweet: String!): Tweet!
-
-    # Create user info is available in dynamo integration
-	updateUserInfo(
-		location: String!,
-		description: String!,
-		name: String!,
-		followers_count: Int!,
-		friends_count: Int!,
-		favourites_count: Int!,
-		followers: [String!]!
-	): User!
+  
+  # Create a tweet for a user
+  # consumer keys and tokens are not required for dynamo integration
+  createTweet(tweet: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String, created_at: String!): Tweet!
+  
+  # Delete User Tweet
+  deleteTweet(tweet_id: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String): Tweet!
+  
+  # Retweet existing Tweet
+  reTweet(tweet_id: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String): Tweet!
+  
+  # Update existing Tweet
+  updateTweet(tweet_id: String!, tweet: String!): Tweet!
+  
+  # Create user info is available in dynamo integration
+  updateUserInfo(location: String!, description: String!, name: String!, followers_count: Int!, friends_count: Int!, favourites_count: Int!, followers: [String!]!): User!
 }
 
 type Query {
-	meInfo(consumer_key: String, consumer_secret: String): User!
-	getUserInfo(handle: String!, consumer_key: String, consumer_secret: String): User!
-
-	# search functionality is available in elasticsearch integration
-	searchAllTweetsByKeyword(keyword: String!): TweetConnection
+  meInfo(consumer_key: String, consumer_secret: String): User!
+  getUserInfo(handle: String!, consumer_key: String, consumer_secret: String): User!
+  
+  # search functionality is available in elasticsearch integration
+  searchAllTweetsByKeyword(keyword: String!): TweetConnection
 }
 
 type Subscription {
-	addTweet: Tweet
-		@aws_subscribe(mutations: [\\"createTweet\\"])
+  addTweet: Tweet @aws_subscribe(mutations: [\\"createTweet\\"])
 }
 
 type Tweet {
-	tweet_id: String!
-	tweet: String!
-	retweeted: Boolean
-	retweet_count: Int
-	favorited: Boolean
-	created_at: String!
+  tweet_id: String!
+  tweet: String!
+  retweeted: Boolean
+  retweet_count: Int
+  favorited: Boolean
+  created_at: String!
 }
 
 type TweetConnection {
-	items: [Tweet!]!
-	nextToken: String
+  items: [Tweet!]!
+  nextToken: String
 }
 
 type User {
-	name: String!
-	handle: String!
-	location: String!
-	description: String!
-	followers_count: Int!
-	friends_count: Int!
-	favourites_count: Int!
-	followers: [String!]!
-	topTweet: Tweet
-	tweets(limit: Int!, nextToken: String): TweetConnection
-
-	# search functionality is available in elasticsearch integration
-    searchTweetsByKeyword(keyword: String!): TweetConnection
+  name: String!
+  handle: String!
+  location: String!
+  description: String!
+  followers_count: Int!
+  friends_count: Int!
+  favourites_count: Int!
+  followers: [String!]!
+  topTweet: Tweet
+  tweets(limit: Int!, nextToken: String): TweetConnection
+  
+  # search functionality is available in elasticsearch integration
+  searchTweetsByKeyword(keyword: String!): TweetConnection
 }
 
 schema {
-	query: Query
-	mutation: Mutation
-	subscription: Subscription
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
 }
 ",
     "substitutions": Object {},
@@ -360,97 +480,70 @@ Array [
     "name": "api",
     "region": "us-east-1",
     "schema": "type Mutation {
-	# Create a tweet for a user
-	# consumer keys and tokens are not required for dynamo integration
-	createTweet(
-		tweet: String!,
-		consumer_key: String,
-		consumer_secret: String,
-		access_token_key: String,
-		access_token_secret: String,
-		created_at: String!
-	): Tweet!
-
-	# Delete User Tweet
-	deleteTweet(
-	    tweet_id: String!,
-	    consumer_key: String,
-        consumer_secret: String,
-        access_token_key: String,
-        access_token_secret: String
-    ): Tweet!
-
-	# Retweet existing Tweet
-	reTweet(
-	    tweet_id: String!,
-	    consumer_key: String,
-        consumer_secret: String,
-        access_token_key: String,
-        access_token_secret: String
-    ): Tweet!
-
-	# Update existing Tweet
-	updateTweet(tweet_id: String!, tweet: String!): Tweet!
-
-    # Create user info is available in dynamo integration
-	updateUserInfo(
-		location: String!,
-		description: String!,
-		name: String!,
-		followers_count: Int!,
-		friends_count: Int!,
-		favourites_count: Int!,
-		followers: [String!]!
-	): User!
+  
+  # Create a tweet for a user
+  # consumer keys and tokens are not required for dynamo integration
+  createTweet(tweet: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String, created_at: String!): Tweet!
+  
+  # Delete User Tweet
+  deleteTweet(tweet_id: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String): Tweet!
+  
+  # Retweet existing Tweet
+  reTweet(tweet_id: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String): Tweet!
+  
+  # Update existing Tweet
+  updateTweet(tweet_id: String!, tweet: String!): Tweet!
+  
+  # Create user info is available in dynamo integration
+  updateUserInfo(location: String!, description: String!, name: String!, followers_count: Int!, friends_count: Int!, favourites_count: Int!, followers: [String!]!): User!
 }
 
 type Query {
-	meInfo(consumer_key: String, consumer_secret: String): User!
-	getUserInfo(handle: String!, consumer_key: String, consumer_secret: String): User!
-
-	# search functionality is available in elasticsearch integration
-	searchAllTweetsByKeyword(keyword: String!): TweetConnection
+  meInfo(consumer_key: String, consumer_secret: String): User!
+  getUserInfo(handle: String!, consumer_key: String, consumer_secret: String): User!
+  
+  # search functionality is available in elasticsearch integration
+  searchAllTweetsByKeyword(keyword: String!): TweetConnection
 }
 
 type Subscription {
-	addTweet: Tweet
-		@aws_subscribe(mutations: [\\"createTweet\\"])
+  addTweet: Tweet @aws_subscribe(mutations: [\\"createTweet\\"])
 }
 
 type Tweet {
-	tweet_id: String!
-	tweet: String!
-	retweeted: Boolean
-	retweet_count: Int
-	favorited: Boolean
-	created_at: String!
+  tweet_id: String!
+  tweet: String!
+  retweeted: Boolean
+  retweet_count: Int
+  favorited: Boolean
+  created_at: String!
 }
 
 type TweetConnection {
-	items: [Tweet!]!
-	nextToken: String
+  items: [Tweet!]!
+  nextToken: String
 }
 
 type User {
-	name: String!
-	handle: String!
-	location: String!
-	description: String!
-	followers_count: Int!
-	friends_count: Int!
-	favourites_count: Int!
-	followers: [String!]!
-	topTweet: Tweet
-	tweets(limit: Int!, nextToken: String): TweetConnection
-
-	# search functionality is available in elasticsearch integration
-    searchTweetsByKeyword(keyword: String!): TweetConnection
+  name: String!
+  handle: String!
+  location: String!
+  description: String!
+  followers_count: Int!
+  friends_count: Int!
+  favourites_count: Int!
+  followers: [String!]!
+  topTweet: Tweet
+  tweets(limit: Int!, nextToken: String): TweetConnection
+  
+  # search functionality is available in elasticsearch integration
+  searchTweetsByKeyword(keyword: String!): TweetConnection
 }
 
 schema {
-	query: Query
-	mutation: Mutation
-	subscription: Subscription
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
 }
 ",
     "substitutions": Object {},
@@ -483,97 +576,70 @@ Array [
     "name": "api",
     "region": "us-east-1",
     "schema": "type Mutation {
-	# Create a tweet for a user
-	# consumer keys and tokens are not required for dynamo integration
-	createTweet(
-		tweet: String!,
-		consumer_key: String,
-		consumer_secret: String,
-		access_token_key: String,
-		access_token_secret: String,
-		created_at: String!
-	): Tweet!
-
-	# Delete User Tweet
-	deleteTweet(
-	    tweet_id: String!,
-	    consumer_key: String,
-        consumer_secret: String,
-        access_token_key: String,
-        access_token_secret: String
-    ): Tweet!
-
-	# Retweet existing Tweet
-	reTweet(
-	    tweet_id: String!,
-	    consumer_key: String,
-        consumer_secret: String,
-        access_token_key: String,
-        access_token_secret: String
-    ): Tweet!
-
-	# Update existing Tweet
-	updateTweet(tweet_id: String!, tweet: String!): Tweet!
-
-    # Create user info is available in dynamo integration
-	updateUserInfo(
-		location: String!,
-		description: String!,
-		name: String!,
-		followers_count: Int!,
-		friends_count: Int!,
-		favourites_count: Int!,
-		followers: [String!]!
-	): User!
+  
+  # Create a tweet for a user
+  # consumer keys and tokens are not required for dynamo integration
+  createTweet(tweet: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String, created_at: String!): Tweet!
+  
+  # Delete User Tweet
+  deleteTweet(tweet_id: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String): Tweet!
+  
+  # Retweet existing Tweet
+  reTweet(tweet_id: String!, consumer_key: String, consumer_secret: String, access_token_key: String, access_token_secret: String): Tweet!
+  
+  # Update existing Tweet
+  updateTweet(tweet_id: String!, tweet: String!): Tweet!
+  
+  # Create user info is available in dynamo integration
+  updateUserInfo(location: String!, description: String!, name: String!, followers_count: Int!, friends_count: Int!, favourites_count: Int!, followers: [String!]!): User!
 }
 
 type Query {
-	meInfo(consumer_key: String, consumer_secret: String): User!
-	getUserInfo(handle: String!, consumer_key: String, consumer_secret: String): User!
-
-	# search functionality is available in elasticsearch integration
-	searchAllTweetsByKeyword(keyword: String!): TweetConnection
+  meInfo(consumer_key: String, consumer_secret: String): User!
+  getUserInfo(handle: String!, consumer_key: String, consumer_secret: String): User!
+  
+  # search functionality is available in elasticsearch integration
+  searchAllTweetsByKeyword(keyword: String!): TweetConnection
 }
 
 type Subscription {
-	addTweet: Tweet
-		@aws_subscribe(mutations: [\\"createTweet\\"])
+  addTweet: Tweet @aws_subscribe(mutations: [\\"createTweet\\"])
 }
 
 type Tweet {
-	tweet_id: String!
-	tweet: String!
-	retweeted: Boolean
-	retweet_count: Int
-	favorited: Boolean
-	created_at: String!
+  tweet_id: String!
+  tweet: String!
+  retweeted: Boolean
+  retweet_count: Int
+  favorited: Boolean
+  created_at: String!
 }
 
 type TweetConnection {
-	items: [Tweet!]!
-	nextToken: String
+  items: [Tweet!]!
+  nextToken: String
 }
 
 type User {
-	name: String!
-	handle: String!
-	location: String!
-	description: String!
-	followers_count: Int!
-	friends_count: Int!
-	favourites_count: Int!
-	followers: [String!]!
-	topTweet: Tweet
-	tweets(limit: Int!, nextToken: String): TweetConnection
-
-	# search functionality is available in elasticsearch integration
-    searchTweetsByKeyword(keyword: String!): TweetConnection
+  name: String!
+  handle: String!
+  location: String!
+  description: String!
+  followers_count: Int!
+  friends_count: Int!
+  favourites_count: Int!
+  followers: [String!]!
+  topTweet: Tweet
+  tweets(limit: Int!, nextToken: String): TweetConnection
+  
+  # search functionality is available in elasticsearch integration
+  searchTweetsByKeyword(keyword: String!): TweetConnection
 }
 
 schema {
-	query: Query
-	mutation: Mutation
-	subscription: Subscription
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
 }
 ",
     "substitutions": Object {},

--- a/get-config.test.js
+++ b/get-config.test.js
@@ -108,3 +108,25 @@ test('Schema as array', () => {
     servicePath,
   )).toMatchSnapshot();
 });
+
+test('Schema as absolute path', () => {
+  expect(getConfig(
+    {
+      authenticationType: 'AWS_IAM',
+      schema: path.join(servicePath, 'schema.graphql'),
+    },
+    { region: 'us-east-1' },
+    servicePath,
+  )).toMatchSnapshot();
+});
+
+test('Schema as glob pattern', () => {
+  expect(getConfig(
+    {
+      authenticationType: 'AWS_IAM',
+      schema: '_type_*.graphql',
+    },
+    { region: 'us-east-1' },
+    servicePath,
+  )).toMatchSnapshot();
+});

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@graphql-tools/merge": "^6.0.16",
     "aws-sdk": "^2.404.0",
     "chalk": "^2.4.2",
+    "globby": "^11.0.3",
     "graphql": "^14.5.8",
     "graphql-playground-middleware-koa": "^1.6.4",
     "koa": "^2.5.2",

--- a/src/get-config.js
+++ b/src/get-config.js
@@ -4,6 +4,7 @@ const { mergeTypeDefs } = require('@graphql-tools/merge');
 const {
   mapObjIndexed, pipe, values, merge,
 } = require('ramda');
+const globby = require('globby');
 
 const objectToArrayWithNameProp = pipe(
   mapObjIndexed((item, key) => merge({ name: key }, item)),
@@ -23,6 +24,7 @@ const mergeTypes = (types, options) => {
     ...options,
   });
 };
+
 
 const getConfig = (config, provider, servicePath) => {
   if (
@@ -58,13 +60,14 @@ const getConfig = (config, provider, servicePath) => {
   const functionConfigurations = config.functionConfigurations || [];
   const mappingTemplates = config.mappingTemplates || [];
 
+  const toAbsolutePath =
+      filePath => (path.isAbsolute(filePath) ? filePath : path.join(servicePath, filePath));
   const readSchemaFile =
-      schemaRelPath => fs.readFileSync(path.join(servicePath, schemaRelPath), { encoding: 'utf8' });
+      filePath => fs.readFileSync(filePath, { encoding: 'utf8' });
 
-  const schemaContent =
-    Array.isArray(config.schema) ?
-      mergeTypes(config.schema.map(readSchemaFile)) :
-      readSchemaFile(config.schema || 'schema.graphql');
+  const schema = Array.isArray(config.schema) ? config.schema : [config.schema || 'schema.graphql'];
+  const schemaFiles = [].concat(...schema.map(s => globby.sync(toAbsolutePath(s))));
+  const schemaContent = mergeTypes(schemaFiles.map(readSchemaFile));
 
   let dataSources = [];
   if (Array.isArray(config.dataSources)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2477,6 +2477,18 @@ fast-glob@^3.0.3:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
+fast-glob@^3.1.1:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
+  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+    picomatch "^2.2.1"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -2997,6 +3009,18 @@ globby@^10.0.2:
     glob "^7.1.3"
     ignore "^5.1.1"
     merge2 "^1.2.3"
+    slash "^3.0.0"
+
+globby@^11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
+  integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
     slash "^3.0.0"
 
 globby@^6.1.0:


### PR DESCRIPTION
Support both glob pattern and absolute path for schema.

```
custom:
  appSync:
    schema:
      - path/**/*.graphql
      - /path/to/schema.graphql
```

Since all schemas are passing through `mergeTypes` by my implementation, the snapshot has changed a lot.

