### PR TITLE
Use buildASTSchema for validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,7 +624,7 @@ custom:
 
 ### Stack Outputs & Exports
 `GraphQlApiId`and `GraphQlApiUrl` are exported to allow cross-stack resource reference using `Fn::ImportValue`.
-Output Exports are named with a `${AWS::StackName}-` prefix to the logical IDs. For example, `${AWS::StackName}-GraphQlApiId`. 
+Output Exports are named with a `${AWS::StackName}-` prefix to the logical IDs. For example, `${AWS::StackName}-GraphQlApiId`.
 > Note: CloudFormation stack outputs and logical IDs will be changed from the defaults to api name prefixed. This allows you to differentiate the APIs on your stack if you want to work with multiple APIs.
 # Cli Usage
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const parseSchema = require('graphql/language').parse;
+const { buildASTSchema } = require('graphql/utilities');
 const runPlayground = require('./graphql-playground');
 const getConfig = require('./get-config');
 const chalk = require('chalk');
@@ -234,10 +235,18 @@ class ServerlessAppsyncPlugin {
     );
   }
 
-  getSchemas() {
+  validateSchemas() {
     const config = this.loadConfig();
 
     const awsTypes = `
+      directive @aws_iam on FIELD_DEFINITION | OBJECT
+      directive @aws_oidc on FIELD_DEFINITION | OBJECT
+      directive @aws_api_key on FIELD_DEFINITION | OBJECT
+      directive @aws_auth(cognito_groups: [String]) on FIELD_DEFINITION | OBJECT
+      directive @aws_cognito_user_pools(
+        cognito_groups: [String]
+      ) on FIELD_DEFINITION | OBJECT
+
       scalar AWSDate
       scalar AWSTime
       scalar AWSDateTime
@@ -249,12 +258,10 @@ class ServerlessAppsyncPlugin {
       scalar AWSIPAddress
     `;
 
-    return config.map(apiConfig => `${apiConfig.schema} ${awsTypes}`);
-  }
-
-  validateSchemas() {
     try {
-      this.getSchemas().forEach(parseSchema);
+      config.forEach((apiConfig) => {
+        buildASTSchema(parseSchema(`${apiConfig.schema} ${awsTypes}`));
+      });
       this.log('GraphQl schema valid');
     } catch (errors) {
       this.log(errors, { color: 'red' });


### PR DESCRIPTION
Closes #402 

The rationale behind this PR is mostly explained in the issue. But here is another tl;dr:

```garphql
type Test @cognito_user_pool {
  field: Strin
}
```

The example above (has missing `aws_` prefix in auth directive as well as typo in String type) passes the old validation but fails the new one.

Added config option `validatieSyntaxOnly` which falls back to previous validation behavior. This can be used as an escape hatch until the stubs are updated in case appsync adds new types or changes the existing ones.