### PR TITLE
Fix schema path globbing on Windows

### DIFF
--- a/src/get-config.js
+++ b/src/get-config.js
@@ -61,13 +61,13 @@ const getConfig = (config, provider, servicePath) => {
   const functionConfigurations = config.functionConfigurations || [];
   const mappingTemplates = config.mappingTemplates || [];
 
-  const toAbsolutePath =
-      filePath => (path.isAbsolute(filePath) ? filePath : path.join(servicePath, filePath));
+  const toAbsolutePosixPath =
+      filePath => (path.isAbsolute(filePath) ? filePath : path.join(servicePath, filePath)).replace(/\\/g, '/');
   const readSchemaFile =
       filePath => fs.readFileSync(filePath, { encoding: 'utf8' });
 
   const schema = Array.isArray(config.schema) ? config.schema : [config.schema || 'schema.graphql'];
-  const schemaFiles = [].concat(...schema.map(s => globby.sync(toAbsolutePath(s))));
+  const schemaFiles = [].concat(...schema.map(s => globby.sync(toAbsolutePosixPath(s))));
   const schemaContent = mergeTypes(schemaFiles.map(readSchemaFile));
 
   let dataSources = [];


### PR DESCRIPTION
Fixes #404 

The issue is caused by `globby` not working with windows paths as patterns. More precisely `fast-glob` which is what `globby` is based on does not support windows paths as patterns and it seems to be intentional, so I don't think it will change anytime soon. `fast-glob` recommends [replacing `\\` with `/`](https://github.com/mrmlnc/fast-glob#how-to-write-patterns-on-windows) so I did that and it worked. 