### PR TITLE
Fix: add support for Managed Rule Groups in WAF

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,31 @@ wafConfig:
     - disableIntrospection  # disables introspection for everyone
 ````
 
+### Using AWS Managed Rules
+
+You can use
+[AWS Managed Rules](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups.html)
+using this configuration:
+
+```yml
+wafConfig:
+  enabled: true
+  rules:
+    - name: MyRule1 # this is your rule name
+      overrideAction:
+        none: {}
+      statement:
+        managedRuleGroupStatement:
+          vendorName: AWS
+          name: AWSManagedRulesCommonRuleSet # this is the name of the managed rule
+```
+
+Managed rules require `overrideAction` set and `action` not set.
+
+For more information view the
+[AWS Managed Rule Groups List](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html).
+
+
 ### Per Api Key rules
 
 In some cases, you might want to enable a rule only for a given API key only. You can specify `wafRules` under the `apiKeys` configuration. The rules will apply only to the api key under which the rule is set.

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -1390,6 +1390,65 @@ Object {
 }
 `;
 
+exports[`WAF should suppress the Action option if OverrideAction is set 1`] = `
+Object {
+  "GraphQlWaf": Object {
+    "Properties": Object {
+      "DefaultAction": Object {
+        "Allow": Object {},
+      },
+      "Description": "ACL rules for AppSync api",
+      "Name": "apiWaf",
+      "Rules": Array [
+        Object {
+          "Name": "MyRule1",
+          "OverrideAction": Object {
+            "None": Object {},
+          },
+          "Priority": 100,
+          "Statement": Object {
+            "ManagedRuleGroupStatement": Object {
+              "Name": "AWSManagedRulesCommonRuleSet",
+              "VendorName": "AWS",
+            },
+          },
+          "VisibilityConfig": Object {
+            "CloudWatchMetricsEnabled": true,
+            "MetricName": "MyRule1",
+            "SampledRequestsEnabled": true,
+          },
+        },
+      ],
+      "Scope": "REGIONAL",
+      "Tags": undefined,
+      "VisibilityConfig": Object {
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "apiWaf",
+        "SampledRequestsEnabled": true,
+      },
+    },
+    "Type": "AWS::WAFv2::WebACL",
+  },
+  "GraphQlWafAssoc": Object {
+    "Properties": Object {
+      "ResourceArn": Object {
+        "Fn::GetAtt": Array [
+          "GraphQlApi",
+          "Arn",
+        ],
+      },
+      "WebACLArn": Object {
+        "Fn::GetAtt": Array [
+          "GraphQlWaf",
+          "Arn",
+        ],
+      },
+    },
+    "Type": "AWS::WAFv2::WebACLAssociation",
+  },
+}
+`;
+
 exports[`api keys should fail with a date > 1 year 1`] = `"Api Key MyKey must be valid for a minimum of 1 day and a maximum of 365 days."`;
 
 exports[`api keys should fail with invalid duration 1`] = `"Could not parse foobar as a valid duration"`;

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -558,7 +558,6 @@ Object {
             "Block": Object {},
           },
           "Name": "UsOnly",
-          "OverrideAction": undefined,
           "Priority": 100,
           "Statement": Object {
             "AndStatement": Object {
@@ -610,7 +609,6 @@ Object {
             "Block": Object {},
           },
           "Name": "Throttle",
-          "OverrideAction": undefined,
           "Priority": 1,
           "Statement": Object {
             "RateBasedStatement": Object {
@@ -651,7 +649,6 @@ Object {
             "Block": Object {},
           },
           "Name": "Throttle",
-          "OverrideAction": undefined,
           "Priority": 1,
           "Statement": Object {
             "RateBasedStatement": Object {
@@ -887,7 +884,6 @@ Object {
             "Allow": Object {},
           },
           "Name": "UsOnly",
-          "OverrideAction": undefined,
           "Priority": 100,
           "Statement": Object {
             "NotStatement": Object {
@@ -1334,7 +1330,6 @@ Object {
             "Allow": Object {},
           },
           "Name": "MatchAllRule",
-          "OverrideAction": undefined,
           "Priority": 100,
           "Statement": Object {
             "ByteMatchStatement": Object {

--- a/index.test.js
+++ b/index.test.js
@@ -1952,4 +1952,29 @@ describe('WAF', () => {
       ['Dummy6', 103],
     ]);
   });
+
+  it('should suppress the Action option if OverrideAction is set', () => {
+    // Using the README example
+    const apiConfig = {
+      ...config,
+      wafConfig: {
+        rules: [
+          {
+            name: 'MyRule1',
+            // This setting should create 'OverrideAction' but suppress 'Action' in the CF output
+            overrideAction: {
+              none: {},
+            },
+            statement: {
+              managedRuleGroupStatement: {
+                vendorName: 'AWS',
+                name: 'AWSManagedRulesCommonRuleSet',
+              },
+            },
+          },
+        ],
+      },
+    };
+    expect(plugin.getWafResources(apiConfig)).toMatchSnapshot();
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1283,14 +1283,19 @@ class ServerlessAppsyncPlugin {
       overrideAction = { [overrideAction]: {} };
     }
 
-    return {
-      Action: action,
+    const result = {
       Name: rule.name,
-      OverrideAction: overrideAction ? toCfnKeys(overrideAction) : undefined,
       Priority: rule.priority,
       Statement: rule.statement ? toCfnKeys(rule.statement) : undefined,
       VisibilityConfig: this.getWafVisibilityConfig(rule.visibilityConfig, rule.name),
     };
+    // only one of Action or OverrideAction is allowed
+    if (overrideAction) {
+      result.OverrideAction = toCfnKeys(overrideAction);
+    } else if (action) {
+      result.Action = action;
+    }
+    return result;
   }
 
   buildWafRules(wafConfig, apiConfig) {


### PR DESCRIPTION
This PR adds support for adding Managed Rule Groups  in WAF.

See https://github.com/sid88in/serverless-appsync-plugin/issues/412 for a discussion of the problem.

I've manually tested the configuration with this YAML:

```
    wafConfig:
      rules:
        - name: MyRule1
          overrideAction:
            none: {}
          statement:
            managedRuleGroupStatement:
              vendorName: AWS
              name: AWSManagedRulesCommonRuleSet
```
