### PR TITLE
feat: aws lambda authorizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ custom:
       appIdClientRegex: # optional      
     # if AWS_LAMBDA
     lambdaAuthorizerConfig:
-      functionName: # The function name in your serverless.yml. Ignored if functionArn is provided.
-      functionArn: # required if functionName is not defined
+      functionName: # The function name in your serverless.yml. Ignored if lambdaFunctionArn is provided.
+      functionAlias: # optional, used with functionName
+      lambdaFunctionArn: # required if functionName is not defined
       identityValidationExpression: # optional
       authorizerResultTtlInSeconds: # optional
     # if OPENID_CONNECT
@@ -102,8 +103,9 @@ custom:
           appIdClientRegex: # optional
       - authenticationType: AWS_LAMBDA
         lambdaAuthorizerConfig:
-          functionName: # The function name in your serverless.yml. Ignored if functionArn is provided.
-          functionArn: # required if functionName is not defined
+          functionName: # The function name in your serverless.yml. Ignored if lambdaFunctionArn is provided.
+          functionAlias: # optional, used with functionName
+          lambdaFunctionArn: # required if functionName is not defined
           identityValidationExpression: # optional
           authorizerResultTtlInSeconds: # optional
     logConfig:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ custom:
     name:  # defaults to api
     # apiKey # only required for update-appsync/delete-appsync
     # apiId # if provided, will update the specified API.
-    authenticationType: API_KEY or AWS_IAM or AMAZON_COGNITO_USER_POOLS or OPENID_CONNECT
+    authenticationType: API_KEY or AWS_IAM or AMAZON_COGNITO_USER_POOLS or OPENID_CONNECT or AWS_LAMBDA
     schema: # schema file or array of files to merge, defaults to schema.graphql (glob pattern is acceptable)
     # Caching options. Disabled by default
     # read more at https://aws.amazon.com/blogs/mobile/appsync-caching-transactions/
@@ -64,7 +64,13 @@ custom:
       awsRegion: # defaults to provider region
       defaultAction: # required # ALLOW or DENY
       userPoolId: # required # user pool ID
-      appIdClientRegex: # optional
+      appIdClientRegex: # optional      
+    # if AWS_LAMBDA
+    lambdaAuthorizerConfig:
+      functionName: # The function name in your serverless.yml. Ignored if functionArn is provided.
+      functionArn: # required if functionName is not defined
+      identityValidationExpression: # optional
+      authorizerResultTtlInSeconds: # optional
     # if OPENID_CONNECT
     openIdConnectConfig:
       issuer:
@@ -94,6 +100,12 @@ custom:
           awsRegion: # defaults to provider region
           userPoolId: # required # user pool ID
           appIdClientRegex: # optional
+      - authenticationType: AWS_LAMBDA
+        lambdaAuthorizerConfig:
+          functionName: # The function name in your serverless.yml. Ignored if functionArn is provided.
+          functionArn: # required if functionName is not defined
+          identityValidationExpression: # optional
+          authorizerResultTtlInSeconds: # optional
     logConfig:
       loggingRoleArn: { Fn::GetAtt: [AppSyncLoggingServiceRole, Arn] } # Where AppSyncLoggingServiceRole is a role with CloudWatch Logs write access
       level: ERROR # Logging Level: NONE | ERROR | ALL

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -1605,6 +1605,7 @@ exports[`appsync config Additional authentication providers created 1`] = `
 Array [
   Object {
     "AuthenticationType": "AMAZON_COGNITO_USER_POOLS",
+    "LambdaAuthorizerConfig": undefined,
     "OpenIDConnectConfig": undefined,
     "UserPoolConfig": Object {
       "AppIdClientRegex": "appIdClientRegex",
@@ -1613,7 +1614,23 @@ Array [
     },
   },
   Object {
+    "AuthenticationType": "AWS_LAMBDA",
+    "LambdaAuthorizerConfig": Object {
+      "AuthorizerResultTtlInSeconds": 300,
+      "AuthorizerUri": Object {
+        "Fn::GetAtt": Array [
+          "LambdaAuthorizerLambdaFunction",
+          "Arn",
+        ],
+      },
+      "IdentityValidationExpression": ".+",
+    },
+    "OpenIDConnectConfig": undefined,
+    "UserPoolConfig": undefined,
+  },
+  Object {
     "AuthenticationType": "OPENID_CONNECT",
+    "LambdaAuthorizerConfig": undefined,
     "OpenIDConnectConfig": Object {
       "AuthTTL": 1000,
       "ClientId": "clientId",
@@ -1624,11 +1641,13 @@ Array [
   },
   Object {
     "AuthenticationType": "API_KEY",
+    "LambdaAuthorizerConfig": undefined,
     "OpenIDConnectConfig": undefined,
     "UserPoolConfig": undefined,
   },
   Object {
     "AuthenticationType": "AWS_IAM",
+    "LambdaAuthorizerConfig": undefined,
     "OpenIDConnectConfig": undefined,
     "UserPoolConfig": undefined,
   },

--- a/index.test.js
+++ b/index.test.js
@@ -526,7 +526,7 @@ describe('appsync config', () => {
     expect(resources.GraphQlApi.Properties.AuthenticationType).toBe('AWS_LAMBDA');
     expect(resources.GraphQlApi.Properties.LambdaAuthorizerConfig).toEqual({
       AuthorizerUri: {
-        'Fn::GetAtt': ['MyTestFunctionLambdaFunction', 'Arn']
+        'Fn::GetAtt': ['MyTestFunctionLambdaFunction', 'Arn'],
       },
       IdentityValidationExpression: '.+',
       AuthorizerResultTtlInSeconds: 300,
@@ -540,7 +540,7 @@ describe('appsync config', () => {
       lambdaAuthorizerConfig: {
         functionName: 'MyTestFunction',
         functionArn: {
-          'Fn::GetAtt': ['MyTestFunction2LambdaFunction', 'Arn']
+          'Fn::GetAtt': ['MyTestFunction2LambdaFunction', 'Arn'],
         },
         identityValidationExpression: '.+',
         authorizerResultTtlInSeconds: 300,
@@ -549,7 +549,7 @@ describe('appsync config', () => {
     expect(resources2.GraphQlApi.Properties.AuthenticationType).toBe('AWS_LAMBDA');
     expect(resources2.GraphQlApi.Properties.LambdaAuthorizerConfig).toEqual({
       AuthorizerUri: {
-        'Fn::GetAtt': ['MyTestFunction2LambdaFunction', 'Arn']
+        'Fn::GetAtt': ['MyTestFunction2LambdaFunction', 'Arn'],
       },
       IdentityValidationExpression: '.+',
       AuthorizerResultTtlInSeconds: 300,
@@ -632,7 +632,7 @@ describe('appsync config', () => {
           lambdaAuthorizerConfig: {
             functionName: 'lambdaAuthorizer',
             identityValidationExpression: '.+',
-            authorizerResultTtlInSeconds: 300
+            authorizerResultTtlInSeconds: 300,
           },
         },
         {

--- a/index.test.js
+++ b/index.test.js
@@ -13,7 +13,7 @@ let config;
 jest.spyOn(Date, 'now').mockImplementation(() => 1607531062000);
 
 jest.mock('fs');
-jest.spyOn(fs, 'readFileSync').mockImplementation(path => `Content: ${path}`);
+jest.spyOn(fs, 'readFileSync').mockImplementation(path => `Content: ${path.replace(/\\/g, '/')}`);
 
 beforeEach(() => {
   const cli = {
@@ -513,6 +513,49 @@ describe('appsync config', () => {
     });
   });
 
+  test('AWS_LAMBDA authorizer config created', () => {
+    const resources = plugin.getGraphQlApiEndpointResource({
+      ...config,
+      authenticationType: 'AWS_LAMBDA',
+      lambdaAuthorizerConfig: {
+        functionName: 'MyTestFunction',
+        identityValidationExpression: '.+',
+        authorizerResultTtlInSeconds: 300,
+      },
+    });
+    expect(resources.GraphQlApi.Properties.AuthenticationType).toBe('AWS_LAMBDA');
+    expect(resources.GraphQlApi.Properties.LambdaAuthorizerConfig).toEqual({
+      AuthorizerUri: {
+        'Fn::GetAtt': ['MyTestFunctionLambdaFunction', 'Arn']
+      },
+      IdentityValidationExpression: '.+',
+      AuthorizerResultTtlInSeconds: 300,
+    });
+
+    // using both `functionName` and `functionArn`
+    // functionArn has priority
+    const resources2 = plugin.getGraphQlApiEndpointResource({
+      ...config,
+      authenticationType: 'AWS_LAMBDA',
+      lambdaAuthorizerConfig: {
+        functionName: 'MyTestFunction',
+        functionArn: {
+          'Fn::GetAtt': ['MyTestFunction2LambdaFunction', 'Arn']
+        },
+        identityValidationExpression: '.+',
+        authorizerResultTtlInSeconds: 300,
+      },
+    });
+    expect(resources2.GraphQlApi.Properties.AuthenticationType).toBe('AWS_LAMBDA');
+    expect(resources2.GraphQlApi.Properties.LambdaAuthorizerConfig).toEqual({
+      AuthorizerUri: {
+        'Fn::GetAtt': ['MyTestFunction2LambdaFunction', 'Arn']
+      },
+      IdentityValidationExpression: '.+',
+      AuthorizerResultTtlInSeconds: 300,
+    });
+  });
+
   test('xrayEnabled config created', () => {
     const resources = plugin.getGraphQlApiEndpointResource({
       ...config,
@@ -582,6 +625,14 @@ describe('appsync config', () => {
             awsRegion: 'eu-central-1',
             userPoolId: 'userPoolGenerateId',
             appIdClientRegex: 'appIdClientRegex',
+          },
+        },
+        {
+          authenticationType: 'AWS_LAMBDA',
+          lambdaAuthorizerConfig: {
+            functionName: 'lambdaAuthorizer',
+            identityValidationExpression: '.+',
+            authorizerResultTtlInSeconds: 300
           },
         },
         {

--- a/index.test.js
+++ b/index.test.js
@@ -532,14 +532,14 @@ describe('appsync config', () => {
       AuthorizerResultTtlInSeconds: 300,
     });
 
-    // using both `functionName` and `functionArn`
-    // functionArn has priority
+    // using both `functionName` and `lambdaFunctionArn`
+    // lambdaFunctionArn has priority
     const resources2 = plugin.getGraphQlApiEndpointResource({
       ...config,
       authenticationType: 'AWS_LAMBDA',
       lambdaAuthorizerConfig: {
         functionName: 'MyTestFunction',
-        functionArn: {
+        lambdaFunctionArn: {
           'Fn::GetAtt': ['MyTestFunction2LambdaFunction', 'Arn'],
         },
         identityValidationExpression: '.+',

--- a/src/get-config.js
+++ b/src/get-config.js
@@ -33,6 +33,7 @@ const getConfig = (config, provider, servicePath) => {
       config.authenticationType === 'AWS_IAM' ||
       config.authenticationType === 'AMAZON_COGNITO_USER_POOLS' ||
       config.authenticationType === 'OPENID_CONNECT' ||
+      config.authenticationType === 'AWS_LAMBDA' ||
       config.apiId
     )
   ) {
@@ -40,6 +41,9 @@ const getConfig = (config, provider, servicePath) => {
   }
   if (config.authenticationType === 'AMAZON_COGNITO_USER_POOLS' && !config.userPoolConfig) {
     throw new Error('appSync property `userPoolConfig` is required when authenticationType `AMAZON_COGNITO_USER_POOLS` is chosen.');
+  }  
+  if (config.authenticationType === 'AWS_LAMBDA' && !config.lambdaAuthorizerConfig) {
+    throw new Error('appSync property `lambdaAuthorizerConfig` is required when authenticationType `AWS_LAMBDA` is chosen.');
   }
   if (config.authenticationType === 'OPENID_CONNECT' && !config.openIdConnectConfig) {
     throw new Error('appSync property `openIdConnectConfig` is required when authenticationType `OPENID_CONNECT` is chosenXXX.');

--- a/src/get-config.js
+++ b/src/get-config.js
@@ -41,7 +41,7 @@ const getConfig = (config, provider, servicePath) => {
   }
   if (config.authenticationType === 'AMAZON_COGNITO_USER_POOLS' && !config.userPoolConfig) {
     throw new Error('appSync property `userPoolConfig` is required when authenticationType `AMAZON_COGNITO_USER_POOLS` is chosen.');
-  }  
+  }
   if (config.authenticationType === 'AWS_LAMBDA' && !config.lambdaAuthorizerConfig) {
     throw new Error('appSync property `lambdaAuthorizerConfig` is required when authenticationType `AWS_LAMBDA` is chosen.');
   }


### PR DESCRIPTION
Last week, AWS released a new way to authorize AppSync APIs, using Lambda functions like in API Gateway.
[Blog Post here 🔗](https://aws.amazon.com/blogs/mobile/appsync-lambda-auth/)

@sweepy84 mentioned this in that issue (#425).

This pull currently covers only the deployment functionality, allow you to setup the Lambda Authorizer in the `serverless.yml` and deploy to the cloud.

I'm not too familiar with the graphql-playground, cause we use another plugin to execute and test locally here, so I glad if someone could help to implement that too. 😃

This is a snippet how to set up the LAMBDA authorizer. You can refer the function logical name (defined in `functions:`) using the `functionName` field, or pass the Arn directly, (or using the intrinsic function `Fn:GetAtt` to get the Arn).
The `lambdaFunctionArn` has priority, if both `lambdaFunctionArn` and `functionName` are defined.
```yml
custom:
  appSync:
    authenticationType: AWS_LAMBDA
    lambdaAuthorizerConfig:
      functionName: lambdaAuthorizer
      # functionAlias: # optional, used with functionName
      # lambdaFunctionArn: # optional if functionName is present
      #   Fn::GetAtt:
      #     - LambdaAuthorizerLambdaFunction
      #     - Arn
      # authorizerResultTtlInSeconds: 300 # optional
      # identityValidationExpression: .+ # optional
#...
functions:
  lambdaAuthorizer:
    name: MyLambdaAuthorizer
    handler: ./src/functions/LambdaAuthorizer.handler
      
```
In your GraphQL schema you should define the new directive `@aws_lambda`. You can use it together with the others auth directives.

```graphql
type Query @aws_api_key @aws_lambda {
  hello_world: String!
  only_lambda: String!
  @aws_lambda
}
```


Some great and useful links:
https://docs.aws.amazon.com/appsync/latest/devguide/security-authz.html#aws-lambda-authorization
https://docs.aws.amazon.com/appsync/latest/APIReference/API_LambdaAuthorizerConfig.html
