### PR TITLE
Fix substitutions from "falsy" values

### DIFF
--- a/__snapshots__/get-config.test.js.snap
+++ b/__snapshots__/get-config.test.js.snap
@@ -79,8 +79,7 @@ schema {
   query: Query
   mutation: Mutation
   subscription: Subscription
-}
-",
+}",
     "substitutions": Object {},
     "xrayEnabled": false,
   },
@@ -146,6 +145,12 @@ type TweetConnection {
   nextToken: String
 }
 
+schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+
 type User {
   name: String!
   handle: String!
@@ -160,14 +165,7 @@ type User {
   
   # search functionality is available in elasticsearch integration
   searchTweetsByKeyword(keyword: String!): TweetConnection
-}
-
-schema {
-  query: Query
-  mutation: Mutation
-  subscription: Subscription
-}
-",
+}",
     "substitutions": Object {},
     "xrayEnabled": false,
   },
@@ -233,6 +231,12 @@ type TweetConnection {
   nextToken: String
 }
 
+schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+
 type User {
   name: String!
   handle: String!
@@ -247,14 +251,7 @@ type User {
   
   # search functionality is available in elasticsearch integration
   searchTweetsByKeyword(keyword: String!): TweetConnection
-}
-
-schema {
-  query: Query
-  mutation: Mutation
-  subscription: Subscription
-}
-",
+}",
     "substitutions": Object {},
     "xrayEnabled": false,
   },
@@ -340,8 +337,7 @@ schema {
   query: Query
   mutation: Mutation
   subscription: Subscription
-}
-",
+}",
     "substitutions": Object {},
     "xrayEnabled": false,
   },
@@ -428,8 +424,7 @@ schema {
   query: Query
   mutation: Mutation
   subscription: Subscription
-}
-",
+}",
     "substitutions": Object {},
     "xrayEnabled": false,
   },
@@ -528,8 +523,7 @@ schema {
   query: Query
   mutation: Mutation
   subscription: Subscription
-}
-",
+}",
     "substitutions": Object {},
     "xrayEnabled": false,
   },
@@ -632,8 +626,7 @@ schema {
   query: Query
   mutation: Mutation
   subscription: Subscription
-}
-",
+}",
     "substitutions": Object {},
     "xrayEnabled": false,
   },
@@ -728,8 +721,7 @@ schema {
   query: Query
   mutation: Mutation
   subscription: Subscription
-}
-",
+}",
     "substitutions": Object {},
     "xrayEnabled": false,
   },

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -2781,7 +2781,7 @@ Object {
 }
 `;
 
-exports[`iamRoleStatements individual template substitutions Substitutions for individual template should override global substitutions. 1`] = `
+exports[`individual template substitutions Substitutions for individual template should override global substitutions. 1`] = `
 Object {
   "Fn::Join": Array [
     "",
@@ -2827,7 +2827,7 @@ Object {
 }
 `;
 
-exports[`iamRoleStatements template substitutions Templates with substitutions should be transformed into Fn::Join with Fn::Sub objects 1`] = `
+exports[`template substitutions Templates with substitutions should be transformed into Fn::Join with Fn::Sub objects 1`] = `
 Object {
   "Fn::Join": Array [
     "",

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -2827,6 +2827,44 @@ Object {
 }
 `;
 
+exports[`template substitutions Falsy substitutions work 1`] = `
+Object {
+  "Fn::Join": Array [
+    "",
+    Array [
+      "emptyString=",
+      Object {
+        "Fn::Sub": Array [
+          "\${emptyString}",
+          Object {
+            "emptyString": "",
+          },
+        ],
+      },
+      "booleanFalse=",
+      Object {
+        "Fn::Sub": Array [
+          "\${booleanFalse}",
+          Object {
+            "booleanFalse": false,
+          },
+        ],
+      },
+      "numberZero=",
+      Object {
+        "Fn::Sub": Array [
+          "\${numberZero}",
+          Object {
+            "numberZero": 0,
+          },
+        ],
+      },
+      "",
+    ],
+  ],
+}
+`;
+
 exports[`template substitutions Templates with substitutions should be transformed into Fn::Join with Fn::Sub objects 1`] = `
 Object {
   "Fn::Join": Array [

--- a/index.test.js
+++ b/index.test.js
@@ -1064,64 +1064,64 @@ describe('iamRoleStatements', () => {
     const roles = plugin.getDataSourceIamRolesResouces(config);
     expect(roles).toEqual({});
   });
+});
 
-  describe('template substitutions', () => {
-    test('Templates with substitutions should be transformed into Fn::Join with Fn::Sub objects', () => {
-      const template = '#set($partitionKey = "${globalPK}")\n' +
-        '{\n' +
-        '"version" : "2018-05-29",\n' +
-        '"operation" : "GetItem",\n' +
-        '"key" : {\n' +
-        '"partitionKey": { "S": "${globalPK}" },\n' +
-        '"sortKey": { "S": "${globalSK}" },\n' +
-        '}\n' +
-        '}';
+describe('template substitutions', () => {
+  test('Templates with substitutions should be transformed into Fn::Join with Fn::Sub objects', () => {
+    const template = '#set($partitionKey = "${globalPK}")\n' +
+      '{\n' +
+      '"version" : "2018-05-29",\n' +
+      '"operation" : "GetItem",\n' +
+      '"key" : {\n' +
+      '"partitionKey": { "S": "${globalPK}" },\n' +
+      '"sortKey": { "S": "${globalSK}" },\n' +
+      '}\n' +
+      '}';
 
-      const variables =
-      {
-        globalPK: 'PK',
-        globalSK: 'SK',
-      };
+    const variables =
+    {
+      globalPK: 'PK',
+      globalSK: 'SK',
+    };
 
-      const transformedTemplate = plugin.substituteGlobalTemplateVariables(template, variables);
-      expect(transformedTemplate).toMatchSnapshot();
-    });
+    const transformedTemplate = plugin.substituteGlobalTemplateVariables(template, variables);
+    expect(transformedTemplate).toMatchSnapshot();
   });
+});
 
-  describe('individual template substitutions', () => {
-    test('Substitutions for individual template should override global substitutions.', () => {
-      const template = '#set($partitionKey = "${globalPK}")\n' +
-        '{\n' +
-        '"version" : "2018-05-29",\n' +
-        '"operation" : "GetItem",\n' +
-        '"key" : {\n' +
-        '"partitionKey": { "S": "${globalPK}" },\n' +
-        '"sortKey": { "S": "${globalSK}" },\n' +
-        '}\n' +
-        '}';
+describe('individual template substitutions', () => {
+  test('Substitutions for individual template should override global substitutions.', () => {
+    const template = '#set($partitionKey = "${globalPK}")\n' +
+      '{\n' +
+      '"version" : "2018-05-29",\n' +
+      '"operation" : "GetItem",\n' +
+      '"key" : {\n' +
+      '"partitionKey": { "S": "${globalPK}" },\n' +
+      '"sortKey": { "S": "${globalSK}" },\n' +
+      '}\n' +
+      '}';
 
-      const configuration =
+    const configuration =
+    {
+      substitutions:
       {
-        substitutions:
-        {
-          globalPK: 'WrongValue',
-          globalSK: 'WrongValue',
-        },
-      };
+        globalPK: 'WrongValue',
+        globalSK: 'WrongValue',
+      },
+    };
 
-      const individualSubstitutions =
-      {
-        globalPK: 'PK',
-        globalSK: 'SK',
-      };
+    const individualSubstitutions =
+    {
+      globalPK: 'PK',
+      globalSK: 'SK',
+    };
 
-      const transformedTemplate = plugin.processTemplate(
-        template,
-        configuration,
-        individualSubstitutions,
-      );
-      expect(transformedTemplate).toMatchSnapshot();
-    });
+    const transformedTemplate = plugin.processTemplate(
+      template,
+      configuration,
+      individualSubstitutions,
+    );
+    expect(transformedTemplate).toMatchSnapshot();
   });
 });
 

--- a/index.test.js
+++ b/index.test.js
@@ -1087,6 +1087,24 @@ describe('template substitutions', () => {
     const transformedTemplate = plugin.substituteGlobalTemplateVariables(template, variables);
     expect(transformedTemplate).toMatchSnapshot();
   });
+
+  test('Falsy substitutions work', () => {
+    const template = [
+      'emptyString=${emptyString}',
+      'booleanFalse=${booleanFalse}',
+      'numberZero=${numberZero}'
+    ].join('');
+
+    const variables =
+    {
+      emptyString: '',
+      booleanFalse: false,
+      numberZero: 0,
+    };
+
+    const transformedTemplate = plugin.substituteGlobalTemplateVariables(template, variables);
+    expect(transformedTemplate).toMatchSnapshot();
+  });
 });
 
 describe('individual template substitutions', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -1543,7 +1543,7 @@ class ServerlessAppsyncPlugin {
 
     const templateJoin = substituteTemplate.split('|||');
     for (let i = 0; i < templateJoin.length; i += 1) {
-      if (substitutions[templateJoin[i]]) {
+      if (typeof substitutions[templateJoin[i]] !== 'undefined') {
         const subs = { [templateJoin[i]]: substitutions[templateJoin[i]] };
         templateJoin[i] = { 'Fn::Sub': [`\${${templateJoin[i]}}`, subs] };
       }


### PR DESCRIPTION
The substitutions feature is nice and really helpful, but it couldn't substitute values such as `false`, `""`, and `0`.

This PR fixes that.