### PR TITLE
chore: add yarn-error.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 npm-debug.log
 yarn-error.json
+yarn-error.log
 users.json
 
 # serverless zip


### PR DESCRIPTION
In #439, yarn-error.log was pushed by mistake, so add it to .gitignore.
