### PR TITLE
feat: support MaxBatchSize

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ custom:
         dataSource: # data source name
         request: # request mapping template name | defaults to {name}.request.vtl
         response: # reponse mapping template name | defaults to {name}.response.vtl
+        maxBatchSize: # maximum number of requests for BatchInvoke operations
     dataSources:
       - type: NONE
         name: none

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ custom:
           - # function name
         request: # request mapping template name | defaults to `defaultMappingTemplates.request` or {type}.{field}.request.vtl
         response: # response mapping template name | defaults to `defaultMappingTemplates.response` or {type}.{field}.response.vtl
+        maxBatchSize: # maximum number of requests for BatchInvoke operations
         # When caching is enaled with `PER_RESOLVER_CACHING`,
         # the caching options of the resolver.
         # Disabled by default.
@@ -759,9 +760,9 @@ You are also very welcome to open a PR and we will gladely review it.
 
 - *Part 1:* [Running a scalable & reliable GraphQL endpoint with Serverless](https://serverless.com/blog/running-scalable-reliable-graphql-endpoint-with-serverless/)
 
-- *Part 2:* [AppSync Backend: AWS Managed GraphQL Service](https://medium.com/@sid88in/running-a-scalable-reliable-graphql-endpoint-with-serverless-24c3bb5acb43)
+- *Part 2:* [AppSync Backend: AWS Managed GraphQL Service](https://medium.com/@sid88in/running-a-scalable-reliable-graphql-endpoint-with-serverless-24c3bb5acb43)
 
-- *Part 3:* [AppSync Frontend: AWS Managed GraphQL Service](https://hackernoon.com/running-a-scalable-reliable-graphql-endpoint-with-serverless-db16e42dc266)
+- *Part 3:* [AppSync Frontend: AWS Managed GraphQL Service](https://hackernoon.com/running-a-scalable-reliable-graphql-endpoint-with-serverless-db16e42dc266)
 
 - *Part 4:* [Serverless AppSync Plugin: Top 10 New Features](https://medium.com/hackernoon/serverless-appsync-plugin-top-10-new-features-3faaf6789480)
 

--- a/index.test.js
+++ b/index.test.js
@@ -1473,12 +1473,13 @@ describe('Templates', () => {
     };
 
     const apiResources = plugin.getResolverResources(apiConfig);
-    expect(apiResources.GraphQlResolverQueryfield.Properties.MaxBatchSize).toBe(
+    expect(apiResources.GraphQlResolverQueryfield.Properties).toHaveProperty(
+      'MaxBatchSize',
       5,
     );
   });
 
-  test('Pileline Resolver with template', () => {
+  test('Pipeline Resolver with template', () => {
     const apiConfig = {
       ...config,
       functionConfigurationsLocation: 'mapping-templates',
@@ -1501,7 +1502,7 @@ describe('Templates', () => {
     ).toHaveProperty('ResponseMappingTemplate');
   });
 
-  test('Pileline Resolver without template', () => {
+  test('Pipeline Resolver without template', () => {
     const apiConfig = {
       ...config,
       functionConfigurationsLocation: 'mapping-templates',
@@ -1521,6 +1522,25 @@ describe('Templates', () => {
     expect(
       apiResources.GraphQlFunctionConfigurationpipeline.Properties,
     ).not.toHaveProperty('ResponseMappingTemplate');
+  });
+
+  test('Pipeline Resolver with batching', () => {
+    const apiConfig = {
+      ...config,
+      functionConfigurationsLocation: 'mapping-templates',
+      functionConfigurations: [
+        {
+          dataSource: 'ds',
+          name: 'pipeline',
+          maxBatchSize: 5,
+        },
+      ],
+    };
+
+    const apiResources = plugin.getFunctionConfigurationResources(apiConfig);
+    expect(
+      apiResources.GraphQlFunctionConfigurationpipeline.Properties,
+    ).toHaveProperty('MaxBatchSize', 5);
   });
 });
 

--- a/index.test.js
+++ b/index.test.js
@@ -1459,6 +1459,25 @@ describe('Templates', () => {
     ).not.toHaveProperty('ResponseMappingTemplate');
   });
 
+  test('Batch resolvers', () => {
+    const apiConfig = {
+      ...config,
+      mappingTemplates: [
+        {
+          dataSource: 'ds',
+          type: 'Query',
+          field: 'field',
+          maxBatchSize: 5,
+        },
+      ],
+    };
+
+    const apiResources = plugin.getResolverResources(apiConfig);
+    expect(apiResources.GraphQlResolverQueryfield.Properties.MaxBatchSize).toBe(
+      5,
+    );
+  });
+
   test('Pileline Resolver with template', () => {
     const apiConfig = {
       ...config,

--- a/src/index.js
+++ b/src/index.js
@@ -1098,6 +1098,10 @@ class ServerlessAppsyncPlugin {
         FunctionVersion: '2018-05-29',
       };
 
+      if (tpl.maxBatchSize) {
+        Properties.MaxBatchSize = tpl.maxBatchSize;
+      }
+
       const requestTemplate = has('request')(tpl)
         ? tpl.request
         : config.defaultMappingTemplates.request;

--- a/src/index.js
+++ b/src/index.js
@@ -1160,6 +1160,10 @@ class ServerlessAppsyncPlugin {
         FieldName: tpl.field,
       };
 
+      if (tpl.maxBatchSize) {
+        Properties.MaxBatchSize = tpl.maxBatchSize;
+      }
+
       const requestTemplate = has('request')(tpl)
         ? tpl.request
         : config.defaultMappingTemplates.request;


### PR DESCRIPTION
It caught me by surprise that [MaxBachSize](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-maxbatchsize) is not supported.

My project recently reached a point where we are actively exploring ways to squeeze out the last bits of performances, [batching](https://docs.aws.amazon.com/appsync/latest/devguide/tutorial-lambda-resolvers.html#advanced-use-case-batching) is definitely something worth trying.

It is also allowed in [Direct Lambda Resolvers](https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-lambda.html#direct-lambda-resolvers), scroll down to the section **Direct Lambda Resolvers: Batching enabled** to read more.