### PR TITLE
Use modern GraphQL schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,14 @@
       "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/merge": "^8.2.0",
         "@serverless/utils": "^6.0.1",
         "ajv": "^8.8.2",
         "ajv-errors": "^3.0.0",
         "ajv-merge-patch": "^5.0.1",
-        "appsync-schema-converter": "^2.0.0",
         "aws-sdk": "^2.1048.0",
         "chalk": "^4.1.2",
         "globby": "^11.0.4",
-        "graphql": "^15.8.0",
+        "graphql": "^16.3.0",
         "lodash": "^4.17.20",
         "luxon": "^2.1.1",
         "open": "^8.4.0"
@@ -713,29 +711,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
-    },
-    "node_modules/@graphql-tools/merge": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.0.tgz",
-      "integrity": "sha512-nfMLYF7zczjnIbChZtqbvozRfuRweMD1Fe9HHd4RXd3Tcsj6E17srW0QJfxUoIIWh4pitj+XwZAwhj1PWBDU7g==",
-      "dependencies": {
-        "@graphql-tools/utils": "^8.4.0",
-        "tslib": "~2.3.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/utils": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.0.tgz",
-      "integrity": "sha512-jMwLm6YdN+Vbqntg5GHqDvGLpLa/xPSpRs/c40d0rBuel77wo7AaQ8jHeBSpp9y+7kp7HrGSWff1u7yJ7F8ppw==",
-      "dependencies": {
-        "tslib": "~2.3.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.6.0",
@@ -2166,28 +2141,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/appsync-schema-converter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/appsync-schema-converter/-/appsync-schema-converter-2.0.0.tgz",
-      "integrity": "sha512-FrSA+VI+Ku3wTVeY1f+opUHvuKoDbMMSWVPRSXULbBMFwT1CuYaWJXRPa02iApvFskVw57wc59yNT+/OzSIBrA==",
-      "dependencies": {
-        "commander": "^8.3.0"
-      },
-      "bin": {
-        "appsync-schema-converter": "dist/cli.js"
-      },
-      "peerDependencies": {
-        "graphql": "^14.2.0 || ^15.0.0"
-      }
-    },
-    "node_modules/appsync-schema-converter/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/archive-type": {
@@ -5217,11 +5170,11 @@
       }
     },
     "node_modules/graphql": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
-      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
+      "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==",
       "engines": {
-        "node": ">= 10.x"
+        "node": "^12.22.0 || ^14.16.0 || >=16.0.0"
       }
     },
     "node_modules/has": {
@@ -10911,23 +10864,6 @@
         }
       }
     },
-    "@graphql-tools/merge": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.0.tgz",
-      "integrity": "sha512-nfMLYF7zczjnIbChZtqbvozRfuRweMD1Fe9HHd4RXd3Tcsj6E17srW0QJfxUoIIWh4pitj+XwZAwhj1PWBDU7g==",
-      "requires": {
-        "@graphql-tools/utils": "^8.4.0",
-        "tslib": "~2.3.0"
-      }
-    },
-    "@graphql-tools/utils": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.0.tgz",
-      "integrity": "sha512-jMwLm6YdN+Vbqntg5GHqDvGLpLa/xPSpRs/c40d0rBuel77wo7AaQ8jHeBSpp9y+7kp7HrGSWff1u7yJ7F8ppw==",
-      "requires": {
-        "tslib": "~2.3.0"
-      }
-    },
     "@humanwhocodes/config-array": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
@@ -12053,21 +11989,6 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
-      }
-    },
-    "appsync-schema-converter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/appsync-schema-converter/-/appsync-schema-converter-2.0.0.tgz",
-      "integrity": "sha512-FrSA+VI+Ku3wTVeY1f+opUHvuKoDbMMSWVPRSXULbBMFwT1CuYaWJXRPa02iApvFskVw57wc59yNT+/OzSIBrA==",
-      "requires": {
-        "commander": "^8.3.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
-        }
       }
     },
     "archive-type": {
@@ -14429,9 +14350,9 @@
       }
     },
     "graphql": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
-      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw=="
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
+      "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A=="
     },
     "has": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -35,16 +35,14 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "@graphql-tools/merge": "^8.2.0",
     "@serverless/utils": "^6.0.1",
     "ajv": "^8.8.2",
     "ajv-errors": "^3.0.0",
     "ajv-merge-patch": "^5.0.1",
-    "appsync-schema-converter": "^2.0.0",
     "aws-sdk": "^2.1048.0",
     "chalk": "^4.1.2",
     "globby": "^11.0.4",
-    "graphql": "^15.8.0",
+    "graphql": "^16.3.0",
     "lodash": "^4.17.20",
     "luxon": "^2.1.1",
     "open": "^8.4.0"

--- a/src/__tests__/fixtures/schemas/multiple/post.graphql
+++ b/src/__tests__/fixtures/schemas/multiple/post.graphql
@@ -1,0 +1,20 @@
+extend type Query {
+  getPost(id: ID!): Post!
+}
+
+extend type Mutation {
+  createPost(post: PostInput!): Post!
+}
+
+# This is a comment
+type Post {
+  id: ID!
+  title: String!
+}
+
+"""
+This is a description
+"""
+input PostInput {
+  title: String!
+}

--- a/src/__tests__/fixtures/schemas/multiple/schema.graphql
+++ b/src/__tests__/fixtures/schemas/multiple/schema.graphql
@@ -1,0 +1,3 @@
+type Query
+
+type Mutation

--- a/src/__tests__/fixtures/schemas/multiple/user.graphql
+++ b/src/__tests__/fixtures/schemas/multiple/user.graphql
@@ -1,0 +1,17 @@
+extend type Query {
+  getUser: User!
+}
+
+extend type Mutation {
+  createUser(post: UserInput!): User!
+}
+
+type User {
+  id: ID!
+  name: String!
+  posts: [Post!]!
+}
+
+input UserInput {
+  name: String!
+}

--- a/src/__tests__/fixtures/schemas/single/schema.graphql
+++ b/src/__tests__/fixtures/schemas/single/schema.graphql
@@ -1,0 +1,20 @@
+type Query {
+  getUser: User!
+}
+
+type Mutation {
+  createUser(post: UserInput!): User!
+}
+
+"""
+A User
+"""
+type User {
+  id: ID!
+  name: String!
+}
+
+# Input for user
+input UserInput {
+  name: String!
+}

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -1,0 +1,176 @@
+import { Api } from '../resources/Api';
+import { Schema } from '../resources/Schema';
+import * as given from './given';
+
+const plugin = given.plugin();
+
+describe('schema', () => {
+  it('should generate a schema resource', () => {
+    const api = new Api(
+      given.appSyncConfig({
+        schema: ['src/__tests__/fixtures/schemas/single/schema.graphql'],
+      }),
+      plugin,
+    );
+
+    expect(api.compileSchema()).toMatchInlineSnapshot(`
+      Object {
+        "GraphQlSchema": Object {
+          "Properties": Object {
+            "ApiId": Object {
+              "Fn::GetAtt": Array [
+                "GraphQlApi",
+                "ApiId",
+              ],
+            },
+            "Definition": "type Query {
+        getUser: User!
+      }
+
+      type Mutation {
+        createUser(post: UserInput!): User!
+      }
+
+      \\"\\"\\"
+      A User
+      \\"\\"\\"
+      type User {
+        id: ID!
+        name: String!
+      }
+
+      # Input for user
+      input UserInput {
+        name: String!
+      }
+      ",
+          },
+          "Type": "AWS::AppSync::GraphQLSchema",
+        },
+      }
+    `);
+  });
+
+  it('should merge the schemas', () => {
+    const api = new Api(given.appSyncConfig(), plugin);
+    const schema = new Schema(api, [
+      'src/__tests__/fixtures/schemas/multiple/schema.graphql',
+      'src/__tests__/fixtures/schemas/multiple/user.graphql',
+      'src/__tests__/fixtures/schemas/multiple/post.graphql',
+    ]);
+    expect(schema.generateSchema()).toMatchInlineSnapshot(`
+      "type Query {
+        getUser: User!
+        getPost(id: ID!): Post!
+      }
+
+      type Mutation {
+        createUser(post: UserInput!): User!
+        createPost(post: PostInput!): Post!
+      }
+
+      type User {
+        id: ID!
+        name: String!
+        posts: [Post!]!
+      }
+
+      input UserInput {
+        name: String!
+      }
+
+      type Post {
+        id: ID!
+        title: String!
+      }
+
+      \\"\\"\\"This is a description\\"\\"\\"
+      input PostInput {
+        title: String!
+      }"
+    `);
+  });
+
+  it('should merge glob schemas', () => {
+    const api = new Api(given.appSyncConfig(), plugin);
+    const schema = new Schema(api, [
+      'src/__tests__/fixtures/schemas/multiple/*.graphql',
+    ]);
+    expect(schema.generateSchema()).toMatchInlineSnapshot(`
+      "type Post {
+        id: ID!
+        title: String!
+      }
+
+      \\"\\"\\"This is a description\\"\\"\\"
+      input PostInput {
+        title: String!
+      }
+
+      type Query {
+        getPost(id: ID!): Post!
+        getUser: User!
+      }
+
+      type Mutation {
+        createPost(post: PostInput!): Post!
+        createUser(post: UserInput!): User!
+      }
+
+      type User {
+        id: ID!
+        name: String!
+        posts: [Post!]!
+      }
+
+      input UserInput {
+        name: String!
+      }"
+    `);
+  });
+
+  it('should fail if schema is invalid', () => {
+    const api = new Api(
+      given.appSyncConfig({
+        schema: [
+          'src/__tests__/fixtures/schemas/multiple/schema.graphql',
+          'src/__tests__/fixtures/schemas/multiple/user.graphql',
+        ],
+      }),
+      plugin,
+    );
+    expect(() => api.compileSchema()).toThrowErrorMatchingInlineSnapshot(
+      `"Unknown type \\"Post\\"."`,
+    );
+  });
+
+  it('should return single files schemas as-is', () => {
+    const api = new Api(given.appSyncConfig(), plugin);
+    const schema = new Schema(api, [
+      'src/__tests__/fixtures/schemas/single/schema.graphql',
+    ]);
+    expect(schema.generateSchema()).toMatchInlineSnapshot(`
+      "type Query {
+        getUser: User!
+      }
+
+      type Mutation {
+        createUser(post: UserInput!): User!
+      }
+
+      \\"\\"\\"
+      A User
+      \\"\\"\\"
+      type User {
+        id: ID!
+        name: String!
+      }
+
+      # Input for user
+      input UserInput {
+        name: String!
+      }
+      "
+    `);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,6 +271,7 @@ class ServerlessAppsyncPlugin {
       },
       // Commands
       'appsync:validate-schema:run': () => {
+        this.loadConfig();
         this.validateSchemas();
         log.success('AppSync schema valid');
       },
@@ -847,7 +848,7 @@ class ServerlessAppsyncPlugin {
       log.info('Validating AppSync schema');
       if (!this.api) {
         throw new this.serverless.classes.Error(
-          'Could not load hte API. This should not happen.',
+          'Could not load the API. This should not happen.',
         );
       }
       this.api.compileSchema();
@@ -864,7 +865,7 @@ class ServerlessAppsyncPlugin {
   buildAndAppendResources() {
     if (!this.api) {
       throw new this.serverless.classes.Error(
-        'Could not load hte API. This should not happen.',
+        'Could not load the API. This should not happen.',
       );
     }
 
@@ -923,9 +924,7 @@ class ServerlessAppsyncPlugin {
   handleError(message: string) {
     const { configValidationMode } = this.serverless.service;
     if (configValidationMode === 'error') {
-      throw new this.serverless.classes.Error(
-        `Invalid AppSync Schema: ${message}`,
-      );
+      throw new this.serverless.classes.Error(message);
     } else if (configValidationMode === 'warn') {
       log.warning(message);
     }


### PR DESCRIPTION
- Force using modern GraphQL schemas in v2
- Plugin will NOT try to "fix" the schemas to be compatible with AppSync
  - types extending multiple interfaces must use `&` (AppSync will fix)
  - `"""` will be kept as-is. AppSync will drop them. Appsync might also fail when used with `enum`
  - `#` will be removed from schema when merged
- Exception: Appsync does not support [Object extensions](https://spec.graphql.org/October2021/#sec-Object-Extensions). The plugin will merge all the types into one using "official" [utilities](https://graphql.org/graphql-js/utilities/)
- Escape hatch: Single files will be kept as-is.