### PR TITLE
feat(pipelineFunctions): Added the sync options

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -1619,6 +1619,67 @@ describe('SyncConfig', () => {
     expect(result).toMatchSnapshot();
   });
 
+  test('Pipeline Resolver Function uses default', () => {
+    const apiConfig = {
+      ...config,
+      functionConfigurationsLocation: 'mapping-templates',
+      functionConfigurations: [
+        {
+          dataSource: 'ds',
+          name: 'pipeline',
+          request: 'request.vtl',
+          response: 'response.vtl',
+          sync: true,
+        },
+      ],
+    };
+
+    const apiResources = plugin.getFunctionConfigurationResources(apiConfig);
+    expect(
+      apiResources.GraphQlFunctionConfigurationpipeline.Properties,
+    ).toHaveProperty('SyncConfig');
+    expect(apiResources.GraphQlFunctionConfigurationpipeline.Properties.SyncConfig).toEqual({
+      "ConflictDetection": "VERSION",
+    });
+  })
+
+  test('Pipeline Resolver Function uses advanced config', () => {
+    const apiConfig = {
+      ...config,
+      functionConfigurationsLocation: 'mapping-templates',
+      functionConfigurations: [
+        {
+          dataSource: 'ds',
+          name: 'pipeline',
+          request: 'request.vtl',
+          response: 'response.vtl',
+          sync: {
+            conflictDetection: 'VERSION',
+            conflictHandler: 'LAMBDA',
+            functionName: 'syncLambda',
+          },
+        },
+      ],
+    };
+
+    const apiResources = plugin.getFunctionConfigurationResources(apiConfig);
+    expect(
+      apiResources.GraphQlFunctionConfigurationpipeline.Properties,
+    ).toHaveProperty('SyncConfig');
+    expect(apiResources.GraphQlFunctionConfigurationpipeline.Properties.SyncConfig).toEqual({
+      "ConflictDetection": "VERSION",
+      "ConflictHandler": "LAMBDA",
+      "LambdaConflictHandlerConfig": {
+        "LambdaConflictHandlerArn": {
+          "Fn::GetAtt": [
+            "SyncLambdaLambdaFunction",
+            "Arn",
+          ],
+        },
+      },
+    });
+  })
+
   test('Uses lambda config', () => {
     Object.assign(config, {
       mappingTemplates: [

--- a/index.test.js
+++ b/index.test.js
@@ -1638,10 +1638,12 @@ describe('SyncConfig', () => {
     expect(
       apiResources.GraphQlFunctionConfigurationpipeline.Properties,
     ).toHaveProperty('SyncConfig');
-    expect(apiResources.GraphQlFunctionConfigurationpipeline.Properties.SyncConfig).toEqual({
-      "ConflictDetection": "VERSION",
+    expect(
+      apiResources.GraphQlFunctionConfigurationpipeline.Properties.SyncConfig,
+    ).toEqual({
+      ConflictDetection: 'VERSION',
     });
-  })
+  });
 
   test('Pipeline Resolver Function uses advanced config', () => {
     const apiConfig = {
@@ -1666,19 +1668,18 @@ describe('SyncConfig', () => {
     expect(
       apiResources.GraphQlFunctionConfigurationpipeline.Properties,
     ).toHaveProperty('SyncConfig');
-    expect(apiResources.GraphQlFunctionConfigurationpipeline.Properties.SyncConfig).toEqual({
-      "ConflictDetection": "VERSION",
-      "ConflictHandler": "LAMBDA",
-      "LambdaConflictHandlerConfig": {
-        "LambdaConflictHandlerArn": {
-          "Fn::GetAtt": [
-            "SyncLambdaLambdaFunction",
-            "Arn",
-          ],
+    expect(
+      apiResources.GraphQlFunctionConfigurationpipeline.Properties.SyncConfig,
+    ).toEqual({
+      ConflictDetection: 'VERSION',
+      ConflictHandler: 'LAMBDA',
+      LambdaConflictHandlerConfig: {
+        LambdaConflictHandlerArn: {
+          'Fn::GetAtt': ['SyncLambdaLambdaFunction', 'Arn'],
         },
       },
     });
-  })
+  });
 
   test('Uses lambda config', () => {
     Object.assign(config, {

--- a/src/index.js
+++ b/src/index.js
@@ -1240,6 +1240,25 @@ class ServerlessAppsyncPlugin {
         FunctionVersion: '2018-05-29',
       };
 
+      if (tpl.sync === true) {
+        // Use defaults
+        Properties.SyncConfig = {
+          ConflictDetection: 'VERSION',
+        };
+      } else if (typeof tpl.sync === 'object') {
+        Properties.SyncConfig = {
+          ConflictDetection: tpl.sync.conflictDetection,
+          ConflictHandler: tpl.sync.conflictHandler,
+          ...(tpl.sync.conflictHandler === 'LAMBDA'
+            ? {
+                LambdaConflictHandlerConfig: {
+                  LambdaConflictHandlerArn: this.getLambdaArn(tpl.sync),
+                },
+              }
+            : {}),
+        };
+      }
+
       if (tpl.maxBatchSize) {
         Properties.MaxBatchSize = tpl.maxBatchSize;
       }


### PR DESCRIPTION
AWS Cloudformation allows us to set Sync Configuration to functionConfigurations (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-syncconfig) but the package was not really dealing with it and generating the correct code for it.

So I basically copied the code that was parsing this in the Mapping Templates to the function configuration so it works there too. Also, I've tried to add some basic unit testing. Sorry if I'm not following any patterns on the coding! =)

Please let me know if you need any more changes here so this get approved and to production.