### PR TITLE
fix: generate correct dynamodb IamStatement

### DIFF
--- a/src/__tests__/__snapshots__/dataSources.test.ts.snap
+++ b/src/__tests__/__snapshots__/dataSources.test.ts.snap
@@ -312,18 +312,26 @@ Object {
                 "Resource": Array [
                   Object {
                     "Fn::Join": Array [
-                      ":",
+                      "/",
                       Array [
-                        "arn",
-                        "aws",
-                        "dynamodb",
                         Object {
-                          "Ref": "AWS::Region",
+                          "Fn::Join": Array [
+                            ":",
+                            Array [
+                              "arn",
+                              "aws",
+                              "dynamodb",
+                              Object {
+                                "Ref": "AWS::Region",
+                              },
+                              Object {
+                                "Ref": "AWS::AccountId",
+                              },
+                              "table",
+                            ],
+                          ],
                         },
-                        Object {
-                          "Ref": "AWS::AccountId",
-                        },
-                        "table/data",
+                        "data",
                       ],
                     ],
                   },
@@ -344,10 +352,11 @@ Object {
                               Object {
                                 "Ref": "AWS::AccountId",
                               },
-                              "table/data",
+                              "table",
                             ],
                           ],
                         },
+                        "data",
                         "*",
                       ],
                     ],
@@ -433,18 +442,26 @@ Object {
                 "Resource": Array [
                   Object {
                     "Fn::Join": Array [
-                      ":",
+                      "/",
                       Array [
-                        "arn",
-                        "aws",
-                        "dynamodb",
                         Object {
-                          "Ref": "AWS::Region",
+                          "Fn::Join": Array [
+                            ":",
+                            Array [
+                              "arn",
+                              "aws",
+                              "dynamodb",
+                              Object {
+                                "Ref": "AWS::Region",
+                              },
+                              Object {
+                                "Ref": "AWS::AccountId",
+                              },
+                              "table",
+                            ],
+                          ],
                         },
-                        Object {
-                          "Ref": "AWS::AccountId",
-                        },
-                        "table/data",
+                        "data",
                       ],
                     ],
                   },
@@ -465,10 +482,11 @@ Object {
                               Object {
                                 "Ref": "AWS::AccountId",
                               },
-                              "table/data",
+                              "table",
                             ],
                           ],
                         },
+                        "data",
                         "*",
                       ],
                     ],
@@ -552,16 +570,24 @@ Object {
                 "Resource": Array [
                   Object {
                     "Fn::Join": Array [
-                      ":",
+                      "/",
                       Array [
-                        "arn",
-                        "aws",
-                        "dynamodb",
-                        "us-east-2",
                         Object {
-                          "Ref": "AWS::AccountId",
+                          "Fn::Join": Array [
+                            ":",
+                            Array [
+                              "arn",
+                              "aws",
+                              "dynamodb",
+                              "us-east-2",
+                              Object {
+                                "Ref": "AWS::AccountId",
+                              },
+                              "table",
+                            ],
+                          ],
                         },
-                        "table/data",
+                        "data",
                       ],
                     ],
                   },
@@ -580,10 +606,11 @@ Object {
                               Object {
                                 "Ref": "AWS::AccountId",
                               },
-                              "table/data",
+                              "table",
                             ],
                           ],
                         },
+                        "data",
                         "*",
                       ],
                     ],

--- a/src/__tests__/__snapshots__/dataSources.test.ts.snap
+++ b/src/__tests__/__snapshots__/dataSources.test.ts.snap
@@ -505,6 +505,142 @@ Object {
 }
 `;
 
+exports[`DataSource DynamoDB should generate default role with a Ref for the table name 1`] = `
+Object {
+  "GraphQlDsdynamo": Object {
+    "Properties": Object {
+      "ApiId": Object {
+        "Fn::GetAtt": Array [
+          "GraphQlApi",
+          "ApiId",
+        ],
+      },
+      "Description": "My dynamo table",
+      "DynamoDBConfig": Object {
+        "AwsRegion": Object {
+          "Ref": "AWS::Region",
+        },
+        "TableName": Object {
+          "Ref": "MyTable",
+        },
+        "UseCallerCredentials": false,
+      },
+      "Name": "dynamo",
+      "ServiceRoleArn": Object {
+        "Fn::GetAtt": Array [
+          "GraphQlDsdynamoRole",
+          "Arn",
+        ],
+      },
+      "Type": "AMAZON_DYNAMODB",
+    },
+    "Type": "AWS::AppSync::DataSource",
+  },
+  "GraphQlDsdynamoRole": Object {
+    "Properties": Object {
+      "AssumeRolePolicyDocument": Object {
+        "Statement": Array [
+          Object {
+            "Action": Array [
+              "sts:AssumeRole",
+            ],
+            "Effect": "Allow",
+            "Principal": Object {
+              "Service": Array [
+                "appsync.amazonaws.com",
+              ],
+            },
+          },
+        ],
+        "Version": "2012-10-17",
+      },
+      "Policies": Array [
+        Object {
+          "PolicyDocument": Object {
+            "Statement": Array [
+              Object {
+                "Action": Array [
+                  "dynamodb:DeleteItem",
+                  "dynamodb:GetItem",
+                  "dynamodb:PutItem",
+                  "dynamodb:Query",
+                  "dynamodb:Scan",
+                  "dynamodb:UpdateItem",
+                  "dynamodb:BatchGetItem",
+                  "dynamodb:BatchWriteItem",
+                  "dynamodb:ConditionCheckItem",
+                ],
+                "Effect": "Allow",
+                "Resource": Array [
+                  Object {
+                    "Fn::Join": Array [
+                      "/",
+                      Array [
+                        Object {
+                          "Fn::Join": Array [
+                            ":",
+                            Array [
+                              "arn",
+                              "aws",
+                              "dynamodb",
+                              Object {
+                                "Ref": "AWS::Region",
+                              },
+                              Object {
+                                "Ref": "AWS::AccountId",
+                              },
+                              "table",
+                            ],
+                          ],
+                        },
+                        Object {
+                          "Ref": "MyTable",
+                        },
+                      ],
+                    ],
+                  },
+                  Object {
+                    "Fn::Join": Array [
+                      "/",
+                      Array [
+                        Object {
+                          "Fn::Join": Array [
+                            ":",
+                            Array [
+                              "arn",
+                              "aws",
+                              "dynamodb",
+                              Object {
+                                "Ref": "AWS::Region",
+                              },
+                              Object {
+                                "Ref": "AWS::AccountId",
+                              },
+                              "table",
+                            ],
+                          ],
+                        },
+                        Object {
+                          "Ref": "MyTable",
+                        },
+                        "*",
+                      ],
+                    ],
+                  },
+                ],
+              },
+            ],
+            "Version": "2012-10-17",
+          },
+          "PolicyName": "AppSync-Datasource-dynamo",
+        },
+      ],
+    },
+    "Type": "AWS::IAM::Role",
+  },
+}
+`;
+
 exports[`DataSource DynamoDB should generate default role with custom region 1`] = `
 Object {
   "GraphQlDsdynamo": Object {

--- a/src/__tests__/dataSources.test.ts
+++ b/src/__tests__/dataSources.test.ts
@@ -55,6 +55,20 @@ describe('DataSource', () => {
       expect(dataSource.compile()).toMatchSnapshot();
     });
 
+    it('should generate default role with a Ref for the table name', () => {
+      const api = new Api(given.appSyncConfig(), plugin);
+      const dataSource = new DataSource(api, {
+        type: 'AMAZON_DYNAMODB',
+        name: 'dynamo',
+        description: 'My dynamo table',
+        config: {
+          tableName: { Ref: 'MyTable' },
+        },
+      });
+
+      expect(dataSource.compile()).toMatchSnapshot();
+    });
+
     it('should generate default role with custom statement', () => {
       const api = new Api(given.appSyncConfig(), plugin);
       const dataSource = new DataSource(api, {

--- a/src/resources/DataSource.ts
+++ b/src/resources/DataSource.ts
@@ -268,7 +268,7 @@ export class DataSource {
               'dynamodb',
               this.config.config.region || { Ref: 'AWS::Region' },
               { Ref: 'AWS::AccountId' },
-              `table/${this.config.config.tableName}`,
+              `table`,
             ],
           ],
         };
@@ -288,8 +288,18 @@ export class DataSource {
           ],
           Effect: 'Allow',
           Resource: [
-            dynamoDbResourceArn,
-            { 'Fn::Join': ['/', [dynamoDbResourceArn, '*']] },
+            {
+              'Fn::Join': [
+                '/',
+                [dynamoDbResourceArn, this.config.config.tableName],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '/',
+                [dynamoDbResourceArn, this.config.config.tableName, '*'],
+              ],
+            },
           ],
         };
 


### PR DESCRIPTION
When defining 

```
dataSources:
    tableDataSource:
      type: AMAZON_DYNAMODB
      description: 'Main table events for everything. Events, users, guests.'
      config:
        tableName: !Ref Table
```

The generated IamRoleStatement is:

```
"Resource": [
                "arn:aws:dynamodb:eu-west-1:679049160385:table/[Object object]",
                "arn:aws:dynamodb:eu-west-1:679049160385:table/[Object object]/*"
            ],
```

This PR fixes that issue.