### PR TITLE
fix : support overrideAction for WAF

### DIFF
--- a/doc/WAF.md
+++ b/doc/WAF.md
@@ -119,6 +119,22 @@ waf:
             - US
 ```
 
+```yml
+waf:
+  enabled: true
+  defaultAction: Block
+  rules:
+    # using ManagedRuleGroup
+    - name: "AWSManagedRulesCommonRuleSet"
+      priority: 20
+      overrideAction:
+        None: {}
+      statement:
+        ManagedRuleGroupStatement:
+          VendorName: "AWS"
+          Name: "AWSManagedRulesCommonRuleSet"
+```
+
 ### Per API Key rules
 
 In some cases, you might want to enable a rule for a given API key only. You can specify `wafRules` under the `appSync.apiKeys` attribute. The rules will apply only to that API key.

--- a/src/__tests__/__snapshots__/waf.test.ts.snap
+++ b/src/__tests__/__snapshots__/waf.test.ts.snap
@@ -411,6 +411,27 @@ Object {
 }
 `;
 
+exports[`Waf Custom rules should generate a custom rule with ManagedRuleGroup 1`] = `
+Object {
+  "Name": "MyRule1",
+  "OverrideAction": Object {
+    "None": Object {},
+  },
+  "Priority": 200,
+  "Statement": Object {
+    "ManagedRuleGroupStatement": Object {
+      "Name": "AWSManagedRulesCommonRuleSet",
+      "VendorName": "AWS",
+    },
+  },
+  "VisibilityConfig": Object {
+    "CloudWatchMetricsEnabled": true,
+    "MetricName": "MyRule1",
+    "SampledRequestsEnabled": true,
+  },
+}
+`;
+
 exports[`Waf Disable introspection should generate a preset rule 1`] = `
 Object {
   "Action": Object {

--- a/src/__tests__/waf.test.ts
+++ b/src/__tests__/waf.test.ts
@@ -168,6 +168,27 @@ describe('Waf', () => {
         ),
       ).toMatchSnapshot();
     });
+
+    it('should generate a custom rule with ManagedRuleGroup', () => {
+      expect(
+        waf.buildWafRule(
+          {
+            name: 'MyRule1',
+            priority: 200,
+            overrideAction: {
+              None: {},
+            },
+            statement: {
+              ManagedRuleGroupStatement: {
+                Name: 'AWSManagedRulesCommonRuleSet',
+                VendorName: 'AWS',
+              },
+            },
+          },
+          'Base',
+        ),
+      ).toMatchSnapshot();
+    });
   });
 
   describe('ApiKey rules', () => {

--- a/src/resources/Waf.ts
+++ b/src/resources/Waf.ts
@@ -14,6 +14,7 @@ import {
   WafThrottleConfig,
 } from '../types/plugin';
 import { Api } from './Api';
+import { toCfnKeys } from '../utils';
 
 export class Waf {
   constructor(private api: Api, private config: WafConfig) {}
@@ -106,10 +107,10 @@ export class Waf {
     }
 
     const action: WafRuleAction = rule.action || 'Allow';
+    const overrideAction = rule.overrideAction;
 
     const result: CfnWafRule = {
       Name: rule.name,
-      Action: { [action]: {} },
       Priority: rule.priority,
       Statement: rule.statement,
       VisibilityConfig: this.getWafVisibilityConfig(
@@ -117,6 +118,12 @@ export class Waf {
         rule.name,
       ),
     };
+
+    if (overrideAction) {
+      result.OverrideAction = toCfnKeys(overrideAction);
+    } else {
+      result.Action = { [action]: {} };
+    }
 
     return result;
   }


### PR DESCRIPTION
Fix for https://github.com/sid88in/serverless-appsync-plugin/issues/578.

When v1 to v2 migration, overrideAction in WAF code was missed to migrate.

override action is typically `None: {}`, or `Count : {}`
https://docs.aws.amazon.com/waf/latest/APIReference/API_OverrideAction.html

I referred around this code in v1 branch.
If `overrideAction` is set, use `overrideAction`. Otherwise, `Action` is used same as before.
https://github.com/sid88in/serverless-appsync-plugin/blob/v1.14.0/src/index.js#L1612

tested with AWS
- cloud formation was generated same as v1
- `sls deploy` suceeded

```
      "Name": "AWSManagedRulesCommonRuleSet",
      "Priority": 20,
      "Statement": {
        "ManagedRuleGroupStatement": {
          "VendorName": "AWS",
          "Name": "AWSManagedRulesCommonRuleSet"
        }
      },
      "VisibilityConfig": {
        "CloudWatchMetricsEnabled": true,
        "MetricName": "AWSManagedRulesCommonRuleSet",
        "SampledRequestsEnabled": true
      },
      "OverrideAction": {
        "None": {}
      }
    },
```