### PR TITLE
fix: make oidc clientId optional

### DIFF
--- a/src/__tests__/validation/__snapshots__/auth.test.ts.snap
+++ b/src/__tests__/validation/__snapshots__/auth.test.ts.snap
@@ -32,10 +32,7 @@ exports[`Valdiation Invalid should validate a Lambda with invalid functionName a
 
 exports[`Valdiation Invalid should validate a Lambda with missing config 1`] = `"/authentication: must have required property 'config'"`;
 
-exports[`Valdiation Invalid should validate a OIDC with empty config 1`] = `
-"/authentication/config: must have required property 'issuer'
-/authentication/config: must have required property 'clientId'"
-`;
+exports[`Valdiation Invalid should validate a OIDC with empty config 1`] = `"/authentication/config: must have required property 'issuer'"`;
 
 exports[`Valdiation Invalid should validate a OIDC with invalid config 1`] = `
 "/authentication/config/issuer: must be string

--- a/src/__tests__/validation/auth.test.ts
+++ b/src/__tests__/validation/auth.test.ts
@@ -62,6 +62,20 @@ describe('Valdiation', () => {
         } as AppSyncConfigInput,
       },
       {
+        name: 'OIDC without a clientId',
+        config: {
+          ...basicConfig,
+          authentication: {
+            type: 'OPENID_CONNECT',
+            config: {
+              issuer: 'https://auth.example.com',
+              iatTTL: 3600,
+              authTTL: 3600,
+            },
+          },
+        } as AppSyncConfigInput,
+      },
+      {
         name: 'IAM',
         config: {
           ...basicConfig,

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -133,7 +133,7 @@ export const appSyncSchema = {
         iatTTL: { type: 'number' },
         authTTL: { type: 'number' },
       },
-      required: ['issuer', 'clientId'],
+      required: ['issuer'],
     },
     iamAuth: {
       type: 'object',


### PR DESCRIPTION
[Documentation](https://github.com/sid88in/serverless-appsync-plugin/blob/master/doc/authentication.md#oidc) states that `clientId` is optional for OIDC, however, the validation in place makes it required. This PR fixes this by making `clientId` optional.