### PR TITLE
docs: Added Substitution example for JS Resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ appSync:
 - [Authentication](doc/authentication.md)
 - [API keys](doc/API-keys.md)
 - [Custom Domain](doc/custom-domain.md)
-- [VTL Template Substitutions](doc/substitutions.md)
+- [Variable Substitutions](doc/substitutions.md)
 - [Caching](doc/caching.md)
 - [Web Application Firewall (WAF)](doc/WAF.md)
 

--- a/doc/pipeline-functions.md
+++ b/doc/pipeline-functions.md
@@ -22,7 +22,7 @@ appSync:
 - `request`: The path to the VTL request mapping template file, relative to `serverless.yml`.
 - `response`: The path to the VTL response mapping template file, relative to `serverless.yml`.
 - `maxBatchSize`: The maximum [batch size](https://aws.amazon.com/blogs/mobile/introducing-configurable-batching-size-for-aws-appsync-lambda-resolvers/) to use (only available for AWS Lambda DataSources)
-- `substitutions`: See [VTL template substitutions](substitutions.md)
+- `substitutions`: See [Variable Substitutions](substitutions.md)
 - `sync`: [See SyncConfig](syncConfig.md)
 
 ## JavaScript vs VTL vs Direct Lambda

--- a/doc/resolvers.md
+++ b/doc/resolvers.md
@@ -28,7 +28,7 @@ appSync:
 - `code`: The path of the JavaScript resolver handler file, relative to `serverless.yml`. If not specified, a [minimalistic default](#javascript-vs-vtl) is used.
 - `request`: The path to the VTL request mapping template file, relative to `serverless.yml`.
 - `response`: The path to the VTL response mapping template file, relative to `serverless.yml`.
-- `substitutions`: See [VTL template substitutions](substitutions.md)
+- `substitutions`: See [Variable Substitutions](substitutions.md)
 - `caching`: [See below](#Caching)
 - `sync`: [See SyncConfig](syncConfig.md)
 

--- a/doc/substitutions.md
+++ b/doc/substitutions.md
@@ -1,10 +1,16 @@
 # Substitutions
 
-Substitutions is a feature that allows you to replace some variables in your VTL mapping templates with dynamic values.
+`Substitutions` is a feature that allows you to replace some variables in your VTL mapping templates or JS resolvers with dynamic values.
 
 They are usually useful to replace parts of the template with resource names or ARNs coming from your IaC, such as a DynamoDB table names, for example; or the stage name, region name, etc.
 
-## Quick start
+## Usage
+
+Substitutions are defined as key-value pairs under the `appSync.substitutions`, `appSync.resolvers.[resolverName].substitutions` or `appSync.pipelineFunctions.[functionName].substitutions` attributes.
+
+Global substitutions are available globally to all mapping templates. Resolver and Pipeline function substitutions are only available where they are defined. Resolver and Pipeline function substitutions take precedence over global substitutions (values will be overwritten).
+
+Once defined, you can then use them within the mapping templates as if they were VTL variables. For JS resolvers you'll need to add the variable name as a string padded by `#`. At deployment time, variables will be substituted with their corresponding value.
 
 ```yaml
 appSync:
@@ -21,43 +27,30 @@ appSync:
         someVariable: someValue
 ```
 
-```vtl
-#set($postsdata = [])
-#foreach($item in ${ctx.args.posts})
-    $util.qr($postsdata.add($util.dynamodb.toMapValues($item)))
-#end
-{
-    "version" : "2018-05-29",
-    "operation" : "BatchPutItem",
-    "tables" : {
-        "${postsTable}": $utils.toJson($postsdata)
-    }
-}
-```
+<details open>
+  <summary>VTL mapping template</summary>
 
-## Usage
+  ```vtl
+  {
+      "version" : "2018-05-29",
+      "operation" : "BatchPutItem",
+      "tables" : {
+          "${postsTable}": [...]
+      }
+  }
+  ```
+</details>
 
-Substitutions are defined as key-value pairs under the `appSync.substitutions`, `appSync.resolvers.[resolverName].substitutions` or `appSync.pipelineFunctions.[functionName].substitutions` attributes.
-
-Global substitutions are available globally to all mapping templates. Resolver and Pipeline function substitutions are only available where they are defined. Resolver and Pipeline function substitutions take precedence over global substitutions (values will be overwritten).
-
-Once defined, you can then use them within the mapping templates as if they were VTL variables. At deployment time, variables will be substituted with their corresponding value.
-
-```yaml
-appSync:
-  name: my-api
-  substitutions:
-    postsTable: !Ref Posts
-```
-
-In the mapping template:
-
-```vtl
-{
-    "version" : "2018-05-29",
-    "operation" : "BatchPutItem",
-    "tables" : {
-        "${postsTable}": [...]
-    }
-}
-```
+<details open>
+  <summary>JS Resolvers</summary>
+  
+  ```js
+  const tableName = '#postsTable#';
+  return {
+    operation: "BatchGetItem",
+    tables: {
+      [tableName]: { keys },
+    },
+  };
+  ```
+</details>


### PR DESCRIPTION
- Removed duplicated code examples on substitutions.md
- Added Example for JS Resolvers
- Updated Links to substitutions.md to display `Variable Substitutions` instead of `VTL template substitutions`