### PR TITLE
feat: support js runtime for unit resolver

### DIFF
--- a/doc/resolvers.md
+++ b/doc/resolvers.md
@@ -33,11 +33,13 @@ appSync:
 - `caching`: [See below](#Caching)
 - `sync`: [See SyncConfig](syncConfig.md)
 
-## JavaScript vs VTL
+## JavaScript, VTL, or Direct Lambda
 
 When `code` is specified, the JavaScript runtime is used. When `request` and/or `response` are specified, the VTL runtime is used.
 
-If neither are specified, by default, the resolver is a PIPELINE JavaScript resolver, and the following minimalistic resolver handler is used.
+For [direct lambda](https://docs.aws.amazon.com/appsync/latest/devguide/direct-lambda-reference.html), set `kind` to `UNIT` and don't specify `request`, `response` or `code`. This only works with Lambda function data sources.
+
+If nothing specified, by default, the resolver is a PIPELINE JavaScript resolver, and the following minimalistic resolver handler is used.
 
 ```js
 export function request() {
@@ -49,7 +51,7 @@ export function response(ctx) {
 }
 ```
 
-If you want to use a UNIT JavaScript resolver, you must specify `code` (the minimalistic resolver handler cannot be used for UNIT resolver).
+Example of a UNIT JavaScript resolver.
 
 ```yaml
 appSync:
@@ -59,8 +61,6 @@ appSync:
       dataSource: myDataSource
       code: getUser.js
 ```
-
-To use [direct lambda](https://docs.aws.amazon.com/appsync/latest/devguide/direct-lambda-reference.html), set `kind` to `UNIT` and don't specify `request`, `response` or `code` (only works with Lambda function data sources).
 
 ## PIPELINE resolvers
 

--- a/doc/resolvers.md
+++ b/doc/resolvers.md
@@ -35,11 +35,13 @@ appSync:
 
 ## JavaScript, VTL, or Direct Lambda
 
-When `code` is specified, the JavaScript runtime is used. When `request` and/or `response` are specified, the VTL runtime is used.
+When `code` is specified, the JavaScript runtime is used.
+
+When `request` and/or `response` are specified, the VTL runtime is used.
 
 For [direct lambda](https://docs.aws.amazon.com/appsync/latest/devguide/direct-lambda-reference.html), set `kind` to `UNIT` and don't specify `request`, `response` or `code`. This only works with Lambda function data sources.
 
-If nothing specified, by default, the resolver is a PIPELINE JavaScript resolver, and the following minimalistic resolver handler is used.
+If nothing is specified, by default, the resolver is a PIPELINE JavaScript resolver, and the following minimalistic code is used for the `before` and `after` handlers.
 
 ```js
 export function request() {

--- a/doc/resolvers.md
+++ b/doc/resolvers.md
@@ -49,7 +49,18 @@ export function response(ctx) {
 }
 ```
 
-To use [direct lambda](https://docs.aws.amazon.com/appsync/latest/devguide/direct-lambda-reference.html), set `kind` to `UNIT` and don't specify `request` and `response` (only works with Lambda function data sources).
+If you want to use a UNIT JavaScript resolver, you must specify `code` (the minimalistic resolver handler cannot be used for UNIT resolver).
+
+```yaml
+appSync:
+  resolvers:
+    Query.user:
+      kind: UNIT
+      dataSource: myDataSource
+      code: getUser.js
+```
+
+To use [direct lambda](https://docs.aws.amazon.com/appsync/latest/devguide/direct-lambda-reference.html), set `kind` to `UNIT` and don't specify `request`, `response` or `code` (only works with Lambda function data sources).
 
 ## PIPELINE resolvers
 

--- a/src/__tests__/resolvers.test.ts
+++ b/src/__tests__/resolvers.test.ts
@@ -76,6 +76,68 @@ describe('Resolvers', () => {
       `);
     });
 
+    it('should generate JS Resources with specific code', () => {
+      const api = new Api(
+        given.appSyncConfig({
+          dataSources: {
+            myTable: {
+              name: 'myTable',
+              type: 'AMAZON_DYNAMODB',
+              config: { tableName: 'data' },
+            },
+          },
+          pipelineFunctions: {
+            getUser: {
+              name: 'getUser',
+              dataSource: 'myTable',
+            },
+          },
+        }),
+        plugin,
+      );
+      expect(
+        api.compileResolver({
+          type: 'Query',
+          kind: 'UNIT',
+          field: 'user',
+          dataSource: 'myTable',
+          code: 'resolvers/getUserFunction.js',
+        }),
+      ).toMatchInlineSnapshot(`
+      Object {
+        "GraphQlResolverQueryuser": Object {
+          "DependsOn": Array [
+            "GraphQlSchema",
+          ],
+          "Properties": Object {
+            "ApiId": Object {
+              "Fn::GetAtt": Array [
+                "GraphQlApi",
+                "ApiId",
+              ],
+            },
+            "Code": "Content of resolvers/getUserFunction.js",
+            "DataSourceName": Object {
+              "Fn::GetAtt": Array [
+                "GraphQlDsmyTable",
+                "Name",
+              ],
+            },
+            "FieldName": "user",
+            "Kind": "UNIT",
+            "MaxBatchSize": undefined,
+            "Runtime": Object {
+              "Name": "APPSYNC_JS",
+              "RuntimeVersion": "1.0.0",
+            },
+            "TypeName": "Query",
+          },
+          "Type": "AWS::AppSync::Resolver",
+        },
+      }
+      `);
+    });
+
     it('should generate Resources with direct Lambda', () => {
       const api = new Api(
         given.appSyncConfig({

--- a/src/__tests__/resolvers.test.ts
+++ b/src/__tests__/resolvers.test.ts
@@ -86,12 +86,6 @@ describe('Resolvers', () => {
               config: { tableName: 'data' },
             },
           },
-          pipelineFunctions: {
-            getUser: {
-              name: 'getUser',
-              dataSource: 'myTable',
-            },
-          },
         }),
         plugin,
       );

--- a/src/resources/Resolver.ts
+++ b/src/resources/Resolver.ts
@@ -32,6 +32,8 @@ export class Resolver {
     };
 
     const isVTLResolver = 'request' in this.config || 'response' in this.config;
+    const isJsResolver =
+      !isVTLResolver && (this.config.kind !== 'UNIT' || 'code' in this.config);
 
     if (isVTLResolver) {
       const requestMappingTemplates = this.resolveMappingTemplate('request');
@@ -43,15 +45,11 @@ export class Resolver {
       if (responseMappingTemplate) {
         Properties.ResponseMappingTemplate = responseMappingTemplate;
       }
-    }
-
-    const isUnitJsResolver = this.config.kind === 'UNIT' && 'code' in this.config;
-    const isPipelineJsResolver = this.config.kind !== 'UNIT' && !isVTLResolver;
-    
-    if(isUnitJsResolver || isPipelineJsResolver) {
+    } else if (isJsResolver) {
       if (this.config.code) {
         Properties.Code = this.resolveJsCode(this.config.code);
       } else {
+        // default for pipeline JS resolvers
         Properties.Code = DEFAULT_JS_RESOLVERS;
       }
       Properties.Runtime = {

--- a/src/resources/Resolver.ts
+++ b/src/resources/Resolver.ts
@@ -33,7 +33,7 @@ export class Resolver {
 
     const isVTLResolver = 'request' in this.config || 'response' in this.config;
     const isJsResolver =
-      !isVTLResolver && (this.config.kind !== 'UNIT' || 'code' in this.config);
+      'code' in this.config || (!isVTLResolver && this.config.kind !== 'UNIT');
 
     if (isJsResolver) {
       if (this.config.code) {

--- a/src/resources/Resolver.ts
+++ b/src/resources/Resolver.ts
@@ -35,17 +35,7 @@ export class Resolver {
     const isJsResolver =
       !isVTLResolver && (this.config.kind !== 'UNIT' || 'code' in this.config);
 
-    if (isVTLResolver) {
-      const requestMappingTemplates = this.resolveMappingTemplate('request');
-      if (requestMappingTemplates) {
-        Properties.RequestMappingTemplate = requestMappingTemplates;
-      }
-
-      const responseMappingTemplate = this.resolveMappingTemplate('response');
-      if (responseMappingTemplate) {
-        Properties.ResponseMappingTemplate = responseMappingTemplate;
-      }
-    } else if (isJsResolver) {
+    if (isJsResolver) {
       if (this.config.code) {
         Properties.Code = this.resolveJsCode(this.config.code);
       } else {
@@ -56,6 +46,16 @@ export class Resolver {
         Name: 'APPSYNC_JS',
         RuntimeVersion: '1.0.0',
       };
+    } else if (isVTLResolver) {
+      const requestMappingTemplates = this.resolveMappingTemplate('request');
+      if (requestMappingTemplates) {
+        Properties.RequestMappingTemplate = requestMappingTemplates;
+      }
+
+      const responseMappingTemplate = this.resolveMappingTemplate('response');
+      if (responseMappingTemplate) {
+        Properties.ResponseMappingTemplate = responseMappingTemplate;
+      }
     }
 
     if (this.config.caching) {

--- a/src/resources/Resolver.ts
+++ b/src/resources/Resolver.ts
@@ -31,16 +31,9 @@ export class Resolver {
       FieldName: this.config.field,
     };
 
-    const isUnitJsResolver =
-      this.config.kind === 'UNIT' && 'code' in this.config;
+    const isVTLResolver = 'request' in this.config || 'response' in this.config;
 
-    const isPipelineJsResolver = !(
-      this.config.kind === 'UNIT' ||
-      'request' in this.config ||
-      'response' in this.config
-    );
-
-    if (!isUnitJsResolver && !isPipelineJsResolver) {
+    if (isVTLResolver) {
       const requestMappingTemplates = this.resolveMappingTemplate('request');
       if (requestMappingTemplates) {
         Properties.RequestMappingTemplate = requestMappingTemplates;
@@ -50,10 +43,15 @@ export class Resolver {
       if (responseMappingTemplate) {
         Properties.ResponseMappingTemplate = responseMappingTemplate;
       }
-    } else {
+    }
+
+    const isUnitJsResolver = this.config.kind === 'UNIT' && 'code' in this.config;
+    const isPipelineJsResolver = this.config.kind !== 'UNIT' && !isVTLResolver;
+    
+    if(isUnitJsResolver || isPipelineJsResolver) {
       if (this.config.code) {
         Properties.Code = this.resolveJsCode(this.config.code);
-      } else if (!this.config.code) {
+      } else {
         Properties.Code = DEFAULT_JS_RESOLVERS;
       }
       Properties.Runtime = {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -151,6 +151,7 @@ export type BaseResolverConfig = {
   type: string;
   request?: string | false;
   response?: string | false;
+  code?: string;
   caching?:
     | {
         ttl?: number;
@@ -171,7 +172,6 @@ export type UnitResolverConfig = BaseResolverConfig & {
 
 export type PipelineResolverConfig = BaseResolverConfig & {
   kind?: 'PIPELINE';
-  code?: string;
   functions: string[];
 };
 


### PR DESCRIPTION
Added support javascript runtime for unit resolver.
https://aws.amazon.com/jp/blogs/mobile/aws-appsync-now-supports-javascript-for-all-resolvers-in-graphql-apis/


Closes #616 