### PR TITLE
fix: use global caching TTL by default in resolver caching config

### DIFF
--- a/src/__tests__/resolvers.test.ts
+++ b/src/__tests__/resolvers.test.ts
@@ -923,5 +923,69 @@ describe('Resolvers', () => {
         }
       `);
     });
+
+    it('should fallback to global caching TTL', () => {
+      const api = new Api(
+        given.appSyncConfig({
+          caching: {
+            behavior: 'PER_RESOLVER_CACHING',
+            ttl: 300,
+          },
+          dataSources: {
+            myTable: {
+              name: 'myTable',
+              type: 'AMAZON_DYNAMODB',
+              config: { tableName: 'data' },
+            },
+          },
+        }),
+        plugin,
+      );
+      expect(
+        api.compileResolver({
+          dataSource: 'myTable',
+          kind: 'UNIT',
+          type: 'Query',
+          field: 'user',
+          caching: {
+            keys: ['$context.identity.sub', '$context.arguments.id'],
+          },
+        }),
+      ).toMatchInlineSnapshot(`
+        Object {
+          "GraphQlResolverQueryuser": Object {
+            "DependsOn": Array [
+              "GraphQlSchema",
+            ],
+            "Properties": Object {
+              "ApiId": Object {
+                "Fn::GetAtt": Array [
+                  "GraphQlApi",
+                  "ApiId",
+                ],
+              },
+              "CachingConfig": Object {
+                "CachingKeys": Array [
+                  "$context.identity.sub",
+                  "$context.arguments.id",
+                ],
+                "Ttl": 300,
+              },
+              "DataSourceName": Object {
+                "Fn::GetAtt": Array [
+                  "GraphQlDsmyTable",
+                  "Name",
+                ],
+              },
+              "FieldName": "user",
+              "Kind": "UNIT",
+              "MaxBatchSize": undefined,
+              "TypeName": "Query",
+            },
+            "Type": "AWS::AppSync::Resolver",
+          },
+        }
+      `);
+    });
   });
 });

--- a/src/resources/Resolver.ts
+++ b/src/resources/Resolver.ts
@@ -58,7 +58,7 @@ export class Resolver {
       } else if (typeof this.config.caching === 'object') {
         Properties.CachingConfig = {
           CachingKeys: this.config.caching.keys,
-          Ttl: this.config.caching.ttl || this.config.caching.ttl || 3600,
+          Ttl: this.config.caching.ttl || this.api.config.caching?.ttl || 3600,
         };
       }
     }


### PR DESCRIPTION
This fixes a regression introduced in `v2` where the per-resolver caching TTL defaults to `3600` even when a global caching TTL is defined.