### PR TITLE
Add support for specifying a custom Logical ID for the AWS::AppSync::GraphQLApi resource

### DIFF
--- a/doc/general-config.md
+++ b/doc/general-config.md
@@ -48,7 +48,7 @@ appSync:
 - `caching`: See [Cacing](caching.md)
 - `waf`: See [Web Application Firefall](WAF.md)
 - `logging`: See [Logging](#Logging)
-- `logicalId`: Optional string. Used to override the generated CloudFormation Logical ID for the `AWS::AppSync::GraphQLApi` resource
+- `logicalIdPrefix`: Optional string. Used to prefix the generated CloudFormation Logical ID for the `AWS::AppSync::GraphQLApi` and related resources
 - `xrayEnabled`: Boolean. Enable or disable X-Ray tracing.
 - `visibility`: Optional. `GLOBAL` or `PRIVATE`. **Changing this value requires the replacement of the API.**
 - `tags`: A key-value pair for tagging this AppSync API

--- a/doc/general-config.md
+++ b/doc/general-config.md
@@ -48,6 +48,7 @@ appSync:
 - `caching`: See [Cacing](caching.md)
 - `waf`: See [Web Application Firefall](WAF.md)
 - `logging`: See [Logging](#Logging)
+- `logicalId`: Optional string. Used to override the generated CloudFormation Logical ID for the `AWS::AppSync::GraphQLApi` resource
 - `xrayEnabled`: Boolean. Enable or disable X-Ray tracing.
 - `visibility`: Optional. `GLOBAL` or `PRIVATE`. **Changing this value requires the replacement of the API.**
 - `tags`: A key-value pair for tagging this AppSync API

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -30,6 +30,36 @@ describe('Api', () => {
       `);
     });
 
+    describe('logicalId', () => {
+      const logicalIdOverride = 'Customlogicalid';
+      it('should override the logical ID if provided', () => {
+        const api = new Api(
+          given.appSyncConfig({
+            logicalId: logicalIdOverride,
+          }),
+          plugin,
+        );
+        expect(api.compileEndpoint()).toMatchInlineSnapshot(`
+        Object {
+          "${logicalIdOverride}": Object {
+            "Properties": Object {
+              "AuthenticationType": "API_KEY",
+              "Name": "MyApi",
+              "Tags": Array [
+                Object {
+                  "Key": "stage",
+                  "Value": "Dev",
+                },
+              ],
+              "XrayEnabled": false,
+            },
+            "Type": "AWS::AppSync::GraphQLApi",
+          },
+        }
+      `);
+      });
+    });
+
     it('should compile the Api Resource for a private endpoint', () => {
       const api = new Api(
         given.appSyncConfig({

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -31,17 +31,17 @@ describe('Api', () => {
     });
 
     describe('logicalId', () => {
-      const logicalIdOverride = 'Customlogicalid';
+      const logicalIdPrefix = 'Logicalidprefix';
       it('should override the logical ID if provided', () => {
         const api = new Api(
           given.appSyncConfig({
-            logicalId: logicalIdOverride,
+            logicalIdPrefix,
           }),
           plugin,
         );
         expect(api.compileEndpoint()).toMatchInlineSnapshot(`
         Object {
-          "${logicalIdOverride}": Object {
+          "${logicalIdPrefix}GraphQlApi": Object {
             "Properties": Object {
               "AuthenticationType": "API_KEY",
               "Name": "MyApi",

--- a/src/index.ts
+++ b/src/index.ts
@@ -958,7 +958,7 @@ class ServerlessAppsyncPlugin {
       }
     }
     const config = getAppSyncConfig(appSync);
-    this.naming = new Naming(appSync.name);
+    this.naming = new Naming(config);
     this.api = new Api(config, this);
   }
 

--- a/src/resources/Api.ts
+++ b/src/resources/Api.ts
@@ -68,7 +68,7 @@ export class Api {
   }
 
   compileEndpoint(): CfnResources {
-    const logicalId = this.naming.getApiLogicalId();
+    const logicalId = this.naming.getApiLogicalId(this.config.logicalId);
 
     const endpointResource: CfnResource = {
       Type: 'AWS::AppSync::GraphQLApi',

--- a/src/resources/Api.ts
+++ b/src/resources/Api.ts
@@ -34,7 +34,7 @@ export class Api {
     public config: AppSyncConfig,
     public plugin: ServerlessAppsyncPlugin,
   ) {
-    this.naming = new Naming(this.config.name);
+    this.naming = new Naming(this.config);
   }
 
   compile() {
@@ -68,7 +68,7 @@ export class Api {
   }
 
   compileEndpoint(): CfnResources {
-    const logicalId = this.naming.getApiLogicalId(this.config.logicalId);
+    const logicalId = this.naming.getApiLogicalId();
 
     const endpointResource: CfnResource = {
       Type: 'AWS::AppSync::GraphQLApi',

--- a/src/resources/Naming.ts
+++ b/src/resources/Naming.ts
@@ -15,8 +15,8 @@ export class Naming {
     return this.getCfnName(name);
   }
 
-  getApiLogicalId() {
-    return this.getLogicalId(`GraphQlApi`);
+  getApiLogicalId(logicalIdOverride?: string) {
+    return this.getLogicalId(logicalIdOverride || `GraphQlApi`);
   }
 
   getSchemaLogicalId() {

--- a/src/resources/Naming.ts
+++ b/src/resources/Naming.ts
@@ -1,22 +1,24 @@
 import {
+  AppSyncConfig,
   DataSourceConfig,
   PipelineFunctionConfig,
   ResolverConfig,
 } from '../types/plugin';
 
 export class Naming {
-  constructor(private apiName: string) {}
+  constructor(private config: AppSyncConfig) {}
 
   getCfnName(name: string) {
     return name.replace(/[^a-zA-Z0-9]/g, '');
   }
 
   getLogicalId(name: string): string {
-    return this.getCfnName(name);
+    const logicalIdPrefix = this.config.logicalIdPrefix || '';
+    return this.getCfnName(`${logicalIdPrefix}${name}`);
   }
 
-  getApiLogicalId(logicalIdOverride?: string) {
-    return this.getLogicalId(logicalIdOverride || `GraphQlApi`);
+  getApiLogicalId() {
+    return this.getLogicalId(`GraphQlApi`);
   }
 
   getSchemaLogicalId() {
@@ -66,7 +68,7 @@ export class Naming {
   // Warning: breaking change.
   // api name added
   getDataSourceLogicalId(name: string) {
-    return `GraphQlDs${this.getLogicalId(name)}`;
+    return this.getLogicalId(`GraphQlDs${name}`);
   }
 
   getDataSourceRoleLogicalId(name: string) {
@@ -104,6 +106,6 @@ export class Naming {
   }
 
   getAuthenticationEmbeddedLamdbaName() {
-    return `${this.apiName}Authorizer`;
+    return `${this.config.name}Authorizer`;
   }
 }

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -12,7 +12,7 @@ export type AppSyncConfig = {
   pipelineFunctions: Record<string, PipelineFunctionConfig>;
   substitutions?: Substitutions;
   xrayEnabled?: boolean;
-  logicalId?: string;
+  logicalIdPrefix?: string;
   logging?: LoggingConfig;
   caching?: CachingConfig;
   waf?: WafConfig;

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -2,7 +2,6 @@ import { CfnWafRuleStatement, IntrinsicFunction } from './cloudFormation';
 
 export type AppSyncConfig = {
   name: string;
-  logicalId?: string;
   schema: string[];
   authentication: Auth;
   additionalAuthentications: Auth[];
@@ -13,6 +12,7 @@ export type AppSyncConfig = {
   pipelineFunctions: Record<string, PipelineFunctionConfig>;
   substitutions?: Substitutions;
   xrayEnabled?: boolean;
+  logicalId?: string;
   logging?: LoggingConfig;
   caching?: CachingConfig;
   waf?: WafConfig;

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -2,6 +2,7 @@ import { CfnWafRuleStatement, IntrinsicFunction } from './cloudFormation';
 
 export type AppSyncConfig = {
   name: string;
+  logicalId?: string;
   schema: string[];
   authentication: Auth;
   additionalAuthentications: Auth[];

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -677,6 +677,7 @@ export const appSyncSchema = {
           'when using CloudFormation, you must provide either certificateArn or hostedZoneId.',
       },
     },
+    logicalIdPrefix: { type: 'string' },
     xrayEnabled: { type: 'boolean' },
     visibility: {
       type: 'string',


### PR DESCRIPTION
Exploring a possible solution to #617 by supporting a parameter to prefix the `AWS::AppSync::GraphQLApi` Logical ID (instead of only supporting `GraphQlApi`)

- [x] Update plugin schema/types
- [x] Add optional override property
- [x] Add unit tests
- [ ] Confirm if approach is acceptable to library creator/maintainer