### PR TITLE
doc: Fix Resolver example

### DIFF
--- a/doc/resolvers.md
+++ b/doc/resolvers.md
@@ -93,6 +93,7 @@ You can even also define the Lambda function definition inline under the dataSou
 appSync:
   resolvers:
     Query.user:
+      kind: UNIT
       dataSource:
         type: 'AWS_LAMBDA'
         config:


### PR DESCRIPTION
`kind: UNIT` was missing from the documentation and has cost me quite a bit of time to figure it out, so I should it'd add it. 🤓