### PR TITLE
fix: schema directives validation

### DIFF
--- a/src/resources/Schema.ts
+++ b/src/resources/Schema.ts
@@ -19,6 +19,7 @@ directive @aws_cognito_user_pools(
   cognito_groups: [String]
 ) on FIELD_DEFINITION | OBJECT
 directive @aws_subscribe(mutations: [String]) on FIELD_DEFINITION
+directive @canonical on OBJECT
 scalar AWSDate
 scalar AWSTime
 scalar AWSDateTime


### PR DESCRIPTION
As a see below, the `@canonical` directive can be used to annotate that a specific field are canonical and can be reused by an associated API.
<img width="829" alt="Screenshot 2023-11-26 at 16 37 57" src="https://github.com/sid88in/serverless-appsync-plugin/assets/1668289/c6aadeb6-4493-418d-a85b-5ba261643918">

But when try to use `@canonical` directive, according to the [AppSync Merged API's spec](https://aws.amazon.com/blogs/mobile/introducing-merged-apis-on-aws-appsync/), results on:
```
Invalid GraphQL schema:
     Unknown directive "@canonical".
```
This PR fix this by adding the support for the `@canonical` directive.
