### PR TITLE
fix: Avoid Log Role Creation when `roleArn` is proivded

### DIFF
--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -327,6 +327,45 @@ describe('Api', () => {
         }
       `);
     });
+
+    it('should compile CloudWatch Resources without additional IAM Role when logging roleARN is provided', () => {
+      const api = new Api(
+        given.appSyncConfig({
+          logging: {
+            level: 'ERROR',
+            retentionInDays: 14,
+            enabled: true,
+            roleArn: 'arn:',
+          },
+        }),
+        plugin,
+      );
+
+      expect(api.compileCloudWatchLogGroup()).toMatchInlineSnapshot(`
+        Object {
+          "GraphQlApiLogGroup": Object {
+            "Properties": Object {
+              "LogGroupName": Object {
+                "Fn::Join": Array [
+                  "/",
+                  Array [
+                    "/aws/appsync/apis",
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "GraphQlApi",
+                        "ApiId",
+                      ],
+                    },
+                  ],
+                ],
+              },
+              "RetentionInDays": 14,
+            },
+            "Type": "AWS::Logs::LogGroup",
+          },
+        }
+      `);
+    });
   });
 
   describe('apiKeys', () => {

--- a/src/resources/Api.ts
+++ b/src/resources/Api.ts
@@ -118,11 +118,9 @@ export class Api {
     }
 
     const logGroupLogicalId = this.naming.getLogGroupLogicalId();
-    const roleLogicalId = this.naming.getLogGroupRoleLogicalId();
-    const policyLogicalId = this.naming.getLogGroupPolicyLogicalId();
     const apiLogicalId = this.naming.getApiLogicalId();
 
-    return {
+    const logGroupCF = {
       [logGroupLogicalId]: {
         Type: 'AWS::Logs::LogGroup',
         Properties: {
@@ -133,10 +131,19 @@ export class Api {
             ],
           },
           RetentionInDays:
-            this.config.logging.retentionInDays ||
+            this.config.logging.retentionInDays ??
             this.plugin.serverless.service.provider.logRetentionInDays,
         },
       },
+    };
+
+    if (this.config.logging.roleArn) return logGroupCF;
+
+    const roleLogicalId = this.naming.getLogGroupRoleLogicalId();
+    const policyLogicalId = this.naming.getLogGroupPolicyLogicalId();
+
+    return {
+      ...logGroupCF,
       [policyLogicalId]: {
         Type: 'AWS::IAM::Policy',
         Properties: {
@@ -418,10 +425,10 @@ export class Api {
       AppIdClientRegex: auth.config.appIdClientRegex,
       ...(!isAdditionalAuth
         ? {
-            // Default action is the one passed in the config
-            // or 'ALLOW'
-            DefaultAction: auth.config.defaultAction || 'ALLOW',
-          }
+          // Default action is the one passed in the config
+          // or 'ALLOW'
+          DefaultAction: auth.config.defaultAction || 'ALLOW',
+        }
         : {}),
     };
 


### PR DESCRIPTION
# Detected Issue:
A new Log Role and policy is always created, without considering if one is provided or not. 

If a `roleArn` is provided in the configuration, that one will be used as `CloudWatchLogsRoleArn`.
```js
      set(endpointResource, 'Properties.LogConfig', {
        CloudWatchLogsRoleArn: this.config.logging.roleArn || {
          'Fn::GetAtt': [logicalIdCloudWatchLogsRole, 'Arn'],
        },
        FieldLogLevel: this.config.logging.level,
        ExcludeVerboseContent: this.config.logging.excludeVerboseContent,
      });
```

The current implementation of `compileCloudWatchLogGroup` will always create a new policy and role alongside the log group:
```js
 return {
      [logGroupLogicalId]: {
        Type: 'AWS::Logs::LogGroup',
        ...
      },
      [policyLogicalId]: {
        Type: 'AWS::IAM::Policy',
        ...
      },
      [roleLogicalId]: {
        Type: 'AWS::IAM::Role',
        ...
      },
    };
```

# Proposed Fix:

Update `compileCloudWatchLogGroup` to consider if `roleArn` is provided or not.

We could see two different scenarios:

* `roleArn` is provided -> only the Log Group should be created
* `roleArn` **not** provided -> Log Group, Policy and Role should be created