### PR TITLE
Support for Amplify directives

### DIFF
--- a/src/resources/Schema.ts
+++ b/src/resources/Schema.ts
@@ -19,6 +19,20 @@ directive @aws_cognito_user_pools(
   cognito_groups: [String]
 ) on FIELD_DEFINITION | OBJECT
 directive @aws_subscribe(mutations: [String]) on FIELD_DEFINITION
+directive @model on OBJECT
+directive @primaryKey on FIELD_DEFINITION
+directive @index on FIELD_DEFINITION
+directive @auth on FIELD_DEFINITION | OBJECT
+directive @hasOne on FIELD_DEFINITION
+directive @hasMany on FIELD_DEFINITION
+directive @belongsTo on FIELD_DEFINITION
+directive @manyToMany on FIELD_DEFINITION
+directive @manyToMany on FIELD_DEFINITION
+directive @function on FIELD_DEFINITION
+directive @predictions on FIELD_DEFINITION
+directive @searchable on FIELD_DEFINITION
+directive @mapsTo on FIELD_DEFINITION
+
 scalar AWSDate
 scalar AWSTime
 scalar AWSDateTime

--- a/src/resources/Schema.ts
+++ b/src/resources/Schema.ts
@@ -30,10 +30,10 @@ directive @manyToMany on FIELD_DEFINITION
 directive @manyToMany on FIELD_DEFINITION
 directive @function on FIELD_DEFINITION
 directive @predictions on FIELD_DEFINITION
-directive @searchable on FIELD_DEFINITION
-directive @mapsTo on FIELD_DEFINITION
+directive @searchable on OBJECT
+directive @mapsTo on OBJECT
 
-scalar AWSDate
+dscalar AWSDate
 scalar AWSTime
 scalar AWSDateTime
 scalar AWSTimestamp


### PR DESCRIPTION
If you are using Amplify in the front-end, there comes some directive that are required for code generation and schema generation, I think we need this awsome plugin to pass the those directives to the serverless deployment, so I added those directives to the Schema.ts