### PR TITLE
feat: IPv6 support

### DIFF
--- a/src/resources/Api.ts
+++ b/src/resources/Api.ts
@@ -277,23 +277,25 @@ export class Api {
 
       merge(resources, {
         [domainRoute53Record]: {
-          Type: 'AWS::Route53::RecordSet',
+          Type: 'AWS::Route53::RecordSetGroup',
           DeletionPolicy: domain.retain ? 'Retain' : 'Delete',
           Properties: {
             ...(domain.hostedZoneId
               ? { HostedZoneId: domain.hostedZoneId }
               : { HostedZoneName: hostedZoneName }),
-            Name: domain.name,
-            Type: 'A',
-            AliasTarget: {
-              HostedZoneId: {
-                'Fn::GetAtt': [domainNameLogicalId, 'HostedZoneId'],
-              },
-              DNSName: {
-                'Fn::GetAtt': [domainNameLogicalId, 'AppSyncDomainName'],
-              },
-              EvaluateTargetHealth: false,
-            },
+            RecordSets: ['A', 'AAAA'].map(Type => ({
+              Name: domain.name,
+              Type,
+              AliasTarget: {
+                HostedZoneId: {
+                  'Fn::GetAtt': [domainNameLogicalId, 'HostedZoneId'],
+                },
+                DNSName: {
+                  'Fn::GetAtt': [domainNameLogicalId, 'AppSyncDomainName'],
+                },
+                EvaluateTargetHealth: false,
+              }
+            }))
           },
         },
       });

--- a/src/resources/Naming.ts
+++ b/src/resources/Naming.ts
@@ -36,7 +36,7 @@ export class Naming {
   }
 
   getDomainReoute53RecordLogicalId() {
-    return this.getLogicalId(`GraphQlDomainRoute53Record`);
+    return this.getLogicalId(`GraphQlDomainRoute53Records`);
   }
 
   getLogGroupLogicalId() {


### PR DESCRIPTION
- turn Route53::RecordSet into a RecordSetGroup with additional AAAA record
- change resource name to avoid type error when updating CloudFormation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom domains now support IPv6 through dual A and AAAA record creation, enhancing connectivity options for users with Route53-managed domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->