### PR TITLE
fix: Deployment using serverless-compose

### DIFF
--- a/src/resources/Schema.ts
+++ b/src/resources/Schema.ts
@@ -58,13 +58,11 @@ export class Schema {
   }
 
   generateSchema() {
-    const schemaFiles = flatten(globby.sync(this.schemas));
+    const cwd = this.api.plugin.serverless.config.servicePath;
+    const schemaFiles = flatten(globby.sync(this.schemas, { cwd }));
 
     const schemas = schemaFiles.map((file) => {
-      return fs.readFileSync(
-        path.join(this.api.plugin.serverless.config.servicePath, file),
-        'utf8',
-      );
+      return fs.readFileSync(path.join(cwd, file), 'utf8');
     });
 
     this.valdiateSchema(AWS_TYPES + '\n' + schemas.join('\n'));


### PR DESCRIPTION
When using serverless-compose to deploy services the current working directory is set to the cwd of the shell. This also occurs when using the `--config` flag to define the path to the `serverless.yml` in a different directory.

This PR sets the cwd used by globby to find the GraphQL schema files to the directory of the `serverless.yml` of the service which matches the behavior described in the [documentation](https://github.com/sid88in/serverless-appsync-plugin/blob/master/doc/general-config.md#Schema).