### PR TITLE
Enable intrinsic function for configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,10 @@
 {
   "name": "serverless-appsync-plugin",
-  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-appsync-plugin",
-      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/merge": "^8.3.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-appsync-plugin",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-appsync-plugin",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/merge": "^8.3.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-appsync-plugin",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-appsync-plugin",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/merge": "^8.3.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-appsync-plugin",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-appsync-plugin",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/merge": "^8.3.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-appsync-plugin",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-appsync-plugin",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/merge": "^8.3.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "serverless-appsync-plugin",
+  "version": "0.0.0-development",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-appsync-plugin",
+      "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/merge": "^8.3.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-appsync-plugin",
-  "version": "0.0.0-development",
+  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-appsync-plugin",
-      "version": "0.0.0-development",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/merge": "^8.3.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-appsync-plugin",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "AWS AppSync support for the Serverless Framework",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-appsync-plugin",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "AWS AppSync support for the Serverless Framework",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "serverless-appsync-plugin",
+  "version": "0.0.0-development",
   "description": "AWS AppSync support for the Serverless Framework",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-appsync-plugin",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "AWS AppSync support for the Serverless Framework",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-appsync-plugin",
-  "version": "0.0.0-development",
+  "version": "0.0.0",
   "description": "AWS AppSync support for the Serverless Framework",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "serverless-appsync-plugin",
+  "name": "@collaborne/serverless-appsync-plugin",
   "version": "0.0.0",
   "description": "AWS AppSync support for the Serverless Framework",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "@collaborne/serverless-appsync-plugin",
-  "version": "0.0.0",
+  "name": "serverless-appsync-plugin",
   "description": "AWS AppSync support for the Serverless Framework",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-appsync-plugin",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "AWS AppSync support for the Serverless Framework",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/src/__tests__/validation/__snapshots__/auth.test.ts.snap
+++ b/src/__tests__/validation/__snapshots__/auth.test.ts.snap
@@ -35,7 +35,7 @@ exports[`Valdiation Invalid should validate a Lambda with missing config 1`] = `
 exports[`Valdiation Invalid should validate a OIDC with empty config 1`] = `"/authentication/config: must have required property 'issuer'"`;
 
 exports[`Valdiation Invalid should validate a OIDC with invalid config 1`] = `
-"/authentication/config/issuer: must be string
+"/authentication/config/issuer: must be a string or a CloudFormation intrinsic function
 /authentication/config/clientId: must be string
 /authentication/config/iatTTL: must be number
 /authentication/config/authTTL: must be number"

--- a/src/__tests__/validation/__snapshots__/auth.test.ts.snap
+++ b/src/__tests__/validation/__snapshots__/auth.test.ts.snap
@@ -16,7 +16,7 @@ exports[`Valdiation Invalid should validate a Lambda with empty config 1`] = `"/
 exports[`Valdiation Invalid should validate a Lambda with invalid config functionnArn 1`] = `
 "/authentication/config/functionArn: must be a string or a CloudFormation intrinsic function
 /authentication/config: must specify functionName, functionArn or function (all exclusives)
-/authentication/config/functionArn: must be string
+/authentication/config/functionArn: must be a string or a CloudFormation intrinsic function
 /authentication/config/identityValidationExpression: must be string
 /authentication/config/authorizerResultTtlInSeconds: must be number"
 `;

--- a/src/__tests__/validation/__snapshots__/base.test.ts.snap
+++ b/src/__tests__/validation/__snapshots__/base.test.ts.snap
@@ -31,8 +31,7 @@ exports[`Valdiation Domain Invalid should validate a useCloudFormation: true, ce
 
 exports[`Valdiation Log Invalid should validate a Invalid 1`] = `
 "/logging/level: must be one of 'ALL', 'ERROR' or 'NONE'
-/logging/retentionInDays: must be integer
-/logging/excludeVerboseContent: must be boolean"
+/logging/retentionInDays: must be integer"
 `;
 
 exports[`Valdiation Waf Invalid should validate a Invalid 1`] = `
@@ -40,8 +39,7 @@ exports[`Valdiation Waf Invalid should validate a Invalid 1`] = `
 /waf/defaultAction: must be 'Allow' or 'Block'
 /waf/rules/0: must be a valid WAF rule
 /waf/rules/1: must be a valid WAF rule
-/waf/rules/2: must be a valid WAF rule
-/waf/enabled: must be boolean"
+/waf/rules/2: must be a valid WAF rule"
 `;
 
 exports[`Valdiation Waf Invalid should validate a Invalid arn 1`] = `"/waf/arn: must be a string or a CloudFormation intrinsic function"`;
@@ -55,7 +53,6 @@ exports[`Valdiation should validate  1`] = `
 ": must have required property 'name'
 : must have required property 'authentication'
 /unknownPorp: invalid (unknown) property
-/xrayEnabled: must be boolean
 /visibility: must be \\"GLOBAL\\" or \\"PRIVATE\\"
 /introspection: must be boolean
 /queryDepthLimit: must be integer

--- a/src/resources/Resolver.ts
+++ b/src/resources/Resolver.ts
@@ -17,6 +17,7 @@ export function request() {
 }
 
 export function response(ctx) {
+  util.http.addResponseHeader('cache-control', 'no-cache');
   return ctx.prev.result;
 }
 `;

--- a/src/resources/Resolver.ts
+++ b/src/resources/Resolver.ts
@@ -17,7 +17,6 @@ export function request() {
 }
 
 export function response(ctx) {
-  util.http.addResponseHeader('cache-control', 'no-cache');
   return ctx.prev.result;
 }
 `;

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -128,7 +128,7 @@ export const appSyncSchema = {
     oidcAuth: {
       type: 'object',
       properties: {
-        issuer: { type: 'string' },
+        issuer: { $ref: '#/definitions/stringOrIntrinsicFunction' },
         clientId: { type: 'string' },
         iatTTL: { type: 'number' },
         authTTL: { type: 'number' },
@@ -630,6 +630,9 @@ export const appSyncSchema = {
       },
       required: ['eventBusArn'],
     },
+    xrayEnabledConfig: {
+      $ref: '#/definitions/lambdaFunctionConfig',
+    },
   },
   properties: {
     name: { type: 'string' },
@@ -685,7 +688,13 @@ export const appSyncSchema = {
           'when using CloudFormation, you must provide either certificateArn or hostedZoneId.',
       },
     },
-    xrayEnabled: { type: 'boolean' },
+    xrayEnabled: {
+      oneOf: [
+        { type: 'boolean' },
+        { $ref: '#/definitions/stringOrIntrinsicFunction' },
+      ],
+      errorMessage: 'must be a boolean or a CloudFormation intrinsic function',
+    },
     visibility: {
       type: 'string',
       enum: ['GLOBAL', 'PRIVATE'],
@@ -699,7 +708,12 @@ export const appSyncSchema = {
     waf: {
       type: 'object',
       properties: {
-        enabled: { type: 'boolean' },
+        enabled: {
+          oneOf: [
+            { type: 'boolean' },
+            { $ref: '#/definitions/stringOrIntrinsicFunction' },
+          ],
+        },
       },
       if: {
         required: ['arn'],
@@ -805,7 +819,12 @@ export const appSyncSchema = {
           errorMessage: "must be one of 'ALL', 'ERROR' or 'NONE'",
         },
         retentionInDays: { type: 'integer' },
-        excludeVerboseContent: { type: 'boolean' },
+        excludeVerboseContent: {
+          oneOf: [
+            { type: 'boolean' },
+            { $ref: '#/definitions/stringOrIntrinsicFunction' },
+          ],
+        },
         enabled: { type: 'boolean' },
       },
       required: ['level'],

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -119,7 +119,7 @@ export const appSyncSchema = {
         // Note: functionName and functionArn are already defined in #/definitions/lambdaFunctionConfig
         // But if not also defined here, TypeScript shows an error.
         functionName: { type: 'string' },
-        functionArn: { type: 'string' },
+        functionArn: { $ref: '#/definitions/stringOrIntrinsicFunction' },
         identityValidationExpression: { type: 'string' },
         authorizerResultTtlInSeconds: { type: 'number' },
       },


### PR DESCRIPTION
This PR enables intrinsic function usage for `xrayEnabled`, `wafEnabled` and `openIdConnectConfig.issuer` fields.

Fixes: https://github.com/sid88in/serverless-appsync-plugin/issues/638