### PR TITLE
fix: incorrect path to schema

### DIFF
--- a/src/resources/Schema.ts
+++ b/src/resources/Schema.ts
@@ -58,13 +58,16 @@ export class Schema {
   }
 
   generateSchema() {
-    const schemaFiles = flatten(globby.sync(this.schemas));
+    const schemaFiles = flatten(
+      globby.sync(
+        this.schemas.map((schema) =>
+          path.join(this.api.plugin.serverless.config.servicePath, schema),
+        ),
+      ),
+    );
 
     const schemas = schemaFiles.map((file) => {
-      return fs.readFileSync(
-        path.join(this.api.plugin.serverless.config.servicePath, file),
-        'utf8',
-      );
+      return fs.readFileSync(file, 'utf8');
     });
 
     this.valdiateSchema(AWS_TYPES + '\n' + schemas.join('\n'));


### PR DESCRIPTION
After updating to serverless v4 I ran into an issue where the generated schema was always empty.

We are using serverless-compose, so we have a folder structure like this:

```
services/
  service-1/
    serverless.yml
  service-2/
    serverless.yml
serverless-compose.yml
```

It seems that the schema files are paths relative to the service directory, but the `cwd` is the root folder, thus none of the schema files can be found. 

This PR should fix that problem and also resolve #648. 