### PR TITLE
feat: Support setting evaluationWindowSec for WAF throttling rule

### DIFF
--- a/doc/WAF.md
+++ b/doc/WAF.md
@@ -69,6 +69,7 @@ waf:
     - throttle: 200 # limit to 200 requests per 5 minutes period
     - throttle:
         limit: 200
+        evaluationWindowSec: 300 # count requests in last 5 minutes, one of 60 | 120 | 300 | 600
         priority: 10
         aggregateKeyType: FORWARDED_IP
         forwardedIPConfig:

--- a/src/__tests__/__snapshots__/waf.test.ts.snap
+++ b/src/__tests__/__snapshots__/waf.test.ts.snap
@@ -183,6 +183,7 @@ Array [
     "Statement": Object {
       "RateBasedStatement": Object {
         "AggregateKeyType": "IP",
+        "EvaluationWindowSec": 300,
         "ForwardedIPConfig": undefined,
         "Limit": 100,
         "ScopeDownStatement": Object {
@@ -229,6 +230,7 @@ Array [
     "Statement": Object {
       "RateBasedStatement": Object {
         "AggregateKeyType": "IP",
+        "EvaluationWindowSec": 300,
         "ForwardedIPConfig": undefined,
         "Limit": 100,
         "ScopeDownStatement": Object {
@@ -483,6 +485,57 @@ Object {
 }
 `;
 
+exports[`Waf Disable introspection should generate a preset rule with custom config 1`] = `
+Object {
+  "Action": Object {
+    "Block": Object {},
+  },
+  "Name": "BaseDisableIntrospection",
+  "Priority": 200,
+  "Statement": Object {
+    "OrStatement": Object {
+      "Statements": Array [
+        Object {
+          "SizeConstraintStatement": Object {
+            "ComparisonOperator": "GT",
+            "FieldToMatch": Object {
+              "Body": Object {},
+            },
+            "Size": 8192,
+            "TextTransformations": Array [
+              Object {
+                "Priority": 0,
+                "Type": "NONE",
+              },
+            ],
+          },
+        },
+        Object {
+          "ByteMatchStatement": Object {
+            "FieldToMatch": Object {
+              "Body": Object {},
+            },
+            "PositionalConstraint": "CONTAINS",
+            "SearchString": "__schema",
+            "TextTransformations": Array [
+              Object {
+                "Priority": 0,
+                "Type": "COMPRESS_WHITE_SPACE",
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+  "VisibilityConfig": Object {
+    "CloudWatchMetricsEnabled": false,
+    "MetricName": "DisableIntrospection",
+    "SampledRequestsEnabled": false,
+  },
+}
+`;
+
 exports[`Waf Disable introspection should generate a preset rule with custon config 1`] = `
 Object {
   "Action": Object {
@@ -544,6 +597,7 @@ Object {
   "Statement": Object {
     "RateBasedStatement": Object {
       "AggregateKeyType": "IP",
+      "EvaluationWindowSec": 300,
       "ForwardedIPConfig": undefined,
       "Limit": 100,
       "ScopeDownStatement": undefined,
@@ -567,6 +621,7 @@ Object {
   "Statement": Object {
     "RateBasedStatement": Object {
       "AggregateKeyType": "FORWARDED_IP",
+      "EvaluationWindowSec": 60,
       "ForwardedIPConfig": Object {
         "FallbackBehavior": "MATCH",
         "HeaderName": "X-Forwarded-To",
@@ -593,6 +648,7 @@ Object {
   "Statement": Object {
     "RateBasedStatement": Object {
       "AggregateKeyType": "IP",
+      "EvaluationWindowSec": 300,
       "ForwardedIPConfig": undefined,
       "Limit": 500,
       "ScopeDownStatement": undefined,

--- a/src/__tests__/waf.test.ts
+++ b/src/__tests__/waf.test.ts
@@ -93,6 +93,7 @@ describe('Waf', () => {
             throttle: {
               priority: 300,
               limit: 200,
+              evaluationWindowSec: 60,
               aggregateKeyType: 'FORWARDED_IP',
               forwardedIPConfig: {
                 headerName: 'X-Forwarded-To',
@@ -125,7 +126,7 @@ describe('Waf', () => {
       ).toMatchSnapshot();
     });
 
-    it('should generate a preset rule with custon config', () => {
+    it('should generate a preset rule with custom config', () => {
       expect(
         waf.buildWafRule(
           {

--- a/src/resources/Waf.ts
+++ b/src/resources/Waf.ts
@@ -294,6 +294,7 @@ export class Waf {
   ): CfnWafRule {
     let Name = `${defaultNamePrefix || ''}Throttle`;
     let Limit = 100;
+    let EvaluationWindowSec = 300;
     let AggregateKeyType = 'IP';
     let ForwardedIPConfig;
     let Priority;
@@ -305,6 +306,7 @@ export class Waf {
       Name = config.name || Name;
       AggregateKeyType = config.aggregateKeyType || AggregateKeyType;
       Limit = config.limit || Limit;
+      EvaluationWindowSec = config.evaluationWindowSec || EvaluationWindowSec;
       Priority = config.priority;
       ScopeDownStatement = config.scopeDownStatement;
       if (AggregateKeyType === 'FORWARDED_IP') {
@@ -326,6 +328,7 @@ export class Waf {
         RateBasedStatement: {
           AggregateKeyType,
           Limit,
+          EvaluationWindowSec,
           ForwardedIPConfig,
           ScopeDownStatement,
         },

--- a/src/types/cloudFormation.ts
+++ b/src/types/cloudFormation.ts
@@ -180,6 +180,7 @@ type CfnWafRuleRateBasedStatement = {
     HeaderName: string;
   };
   Limit: number;
+  EvaluationWindowSec?: number;
   ScopeDownStatement?: CfnWafRuleStatement;
 };
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -23,6 +23,7 @@ export type WafThrottleConfig =
       action?: WafAction;
       aggregateKeyType?: 'IP' | 'FORWARDED_IP';
       limit?: number;
+      evaluationWindowSec?: number;
       priority?: number;
       forwardedIPConfig?: {
         headerName: string;


### PR DESCRIPTION
AWS has added support for custom evaluation windows for the throttling rule of the Web Application Firewall.

https://aws.amazon.com/about-aws/whats-new/2024/03/aws-waf-rate-based-rules-configurable-time-windows/
https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based-high-level-settings.html
https://docs.aws.amazon.com/waf/latest/developerguide/waf-rate-based-example-limit-label-aggregation.html

This PR adds support for this feature.

Note: I edited the test snapshots manually to include the property. Let me know if there is a better way