### PR TITLE
Issue #594 - Added logic to inspect nested stacks for the API ID if it is not found in the main stacks (split-stacks support)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,14 +9,11 @@ import path from 'path';
 import open from 'open';
 import fs from 'fs';
 import {
-  DescribeStackInstanceInput,
-  DescribeStackInstanceOutput,
   DescribeStackResourcesInput,
   DescribeStackResourcesOutput,
   DescribeStacksInput,
   DescribeStacksOutput,
   Outputs,
-  Stack,
 } from 'aws-sdk/clients/cloudformation';
 import {
   AssociateApiRequest,


### PR DESCRIPTION
I took [@tobinc's changes](https://github.com/sid88in/serverless-appsync-plugin/issues/594#issuecomment-2646594494) and refactored them to instead only look in nested cloudformation stacks to get the graphql api's id. This limits the stacks that will need to be investigated to only those that are part of the main stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced AppSync API ID discovery with caching to reduce CloudFormation lookup overhead. The system now comprehensively searches primary and nested stack configurations for more reliable API ID resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sid88in/serverless-appsync-plugin/pull/652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->