### PR TITLE
ci: add newer nodejs version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [16, 18]
+        node: [16, 18, 20, 22, 24]
     steps:
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
This PR adds PR verification with newer Node.js versions 20, 22, 24, 26.