### PR TITLE
chore: add Node.js 26 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [16, 18, 20, 22, 24]
+        node: [16, 18, 20, 22, 24, 26]
     steps:
       - uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
## Proposed changes
This PR adds Node.js 26 version to CI checks. Node.js 26 has been active since [mid-April 2026](https://nodejs.org/en/about/previous-releases), so we should also support it.
