### PR TITLE
fix: allow graphql schema to build properly on Windows

### DIFF
--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -137,6 +137,48 @@ describe('schema', () => {
     `);
   });
 
+  it('should merge glob schemas with Windows paths', () => {
+    const api = new Api(given.appSyncConfig(), plugin);
+    const schema = new Schema(api, [
+      'src\\__tests__\\fixtures\\schemas\\multiple\\*.graphql',
+    ]);
+    expect(schema.generateSchema()).toMatchInlineSnapshot(`
+      "type Mutation {
+        createPost(post: PostInput!): Post!
+        createUser(post: UserInput!): User!
+      }
+
+      type Post @aws_oidc {
+        id: ID!
+        title: String!
+        createdAt: AWSDateTime!
+        updatedAt: AWSDateTime!
+      }
+
+      \\"\\"\\"This is a description\\"\\"\\"
+      input PostInput {
+        title: String!
+      }
+
+      type Query {
+        getPost(id: ID!): Post!
+        getUser: User!
+      }
+
+      type User {
+        id: ID!
+        name: String!
+        role: String! @aws_oidc
+        email: AWSEmail!
+        posts: [Post!]!
+      }
+
+      input UserInput {
+        name: String!
+      }"
+    `);
+  });
+
   it('should fail if schema is invalid', () => {
     const api = new Api(
       given.appSyncConfig({

--- a/src/resources/Schema.ts
+++ b/src/resources/Schema.ts
@@ -63,7 +63,9 @@ export class Schema {
     const schemaFiles = flatten(
       globby.sync(
         this.schemas.map((schema) =>
-          path.join(this.api.plugin.serverless.config.servicePath, schema),
+          path
+            .join(this.api.plugin.serverless.config.servicePath, schema)
+            .replace(/\\/g, '/'),
         ),
       ),
     );


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text.

Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

## Proposed changes
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
-->
When using appsync-serverless-plugin on my Windows laptop, the serverless bundle fails to build properly (the Schema.Definition ends up being empty). Converting the back-slashes to forward-slashes resolves the issue.


## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #333 if this PR closes issue number 333 -->
N/A

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. -->
1. Create project with graphql schema and serverless appsync plugin
2. Open project on Windows machine
3. Attempt to deploy (e.g., sls deploy)
4. Open .serverless/serverless-state.json
5. Observe that GraphQlSchema.Definition is empty
