### PR TITLE
fix(schema): allow @canonical, @hidden, @renamed on FIELD_DEFINITION

### DIFF
--- a/src/__tests__/fixtures/schemas/merge-directives/schema.graphql
+++ b/src/__tests__/fixtures/schemas/merge-directives/schema.graphql
@@ -1,0 +1,20 @@
+type Query {
+  getUser(id: ID!): User! @canonical
+  internalUser(id: ID!): User! @hidden
+  legacyUser(id: ID!): User! @renamed
+}
+
+type User @canonical {
+  id: ID!
+  name: String! @canonical
+  email: String! @hidden
+  oldField: String @renamed
+}
+
+type Post @hidden {
+  id: ID!
+}
+
+type Comment @renamed {
+  id: ID!
+}

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -153,6 +153,18 @@ describe('schema', () => {
     `);
   });
 
+  it('should accept merged-API directives on OBJECT and FIELD_DEFINITION', () => {
+    const api = new Api(
+      given.appSyncConfig({
+        schema: [
+          'src/__tests__/fixtures/schemas/merge-directives/schema.graphql',
+        ],
+      }),
+      plugin,
+    );
+    expect(() => api.compileSchema()).not.toThrow();
+  });
+
   it('should return single files schemas as-is', () => {
     const api = new Api(given.appSyncConfig(), plugin);
     const schema = new Schema(api, [

--- a/src/resources/Schema.ts
+++ b/src/resources/Schema.ts
@@ -18,9 +18,9 @@ directive @aws_cognito_user_pools(
   cognito_groups: [String]
 ) on FIELD_DEFINITION | OBJECT
 directive @aws_subscribe(mutations: [String]) on FIELD_DEFINITION
-directive @canonical on OBJECT
-directive @hidden on OBJECT
-directive @renamed on OBJECT
+directive @canonical on OBJECT | FIELD_DEFINITION
+directive @hidden on OBJECT | FIELD_DEFINITION
+directive @renamed on OBJECT | FIELD_DEFINITION
 scalar AWSDate
 scalar AWSTime
 scalar AWSDateTime


### PR DESCRIPTION
## Summary

`AWS_TYPES` in `src/resources/Schema.ts` declared `@canonical`, `@hidden`, and `@renamed` only on the `OBJECT` location. AWS's [Merged API best-practices guide](https://aws.amazon.com/blogs/mobile/aws-appsync-merged-apis-best-practices-part-2-schema-composition/) explicitly applies these directives to fields too:

- `rating: Int @canonical` — `@canonical` on `FIELD_DEFINITION`
- `authorId: ID! @hidden` — `@hidden` on `FIELD_DEFINITION`
- `getMessage(id: ID!): Message @renamed(to: "getChatMessage")` — `@renamed` on `FIELD_DEFINITION`

The narrow stub causes local SDL validation (`validateSDL`) to reject schemas that follow AWS's documented usage:

```
Invalid GraphQL schema:
     Directive "@canonical" may not be used on FIELD_DEFINITION.
     Directive "@hidden" may not be used on FIELD_DEFINITION.
```

## Changes

```diff
- directive @canonical on OBJECT
- directive @hidden on OBJECT
- directive @renamed on OBJECT
+ directive @canonical on OBJECT | FIELD_DEFINITION
+ directive @hidden on OBJECT | FIELD_DEFINITION
+ directive @renamed on OBJECT | FIELD_DEFINITION
```

Plus a regression test (`schema.test.ts` → `should accept merged-API directives on OBJECT and FIELD_DEFINITION`) with a fixture schema that uses each directive in both locations.

## Known follow-up not included here: the `@renamed(to: String!)` argument

AWS's actual `@renamed` directive takes a required `to: String!` argument, e.g. `@renamed(to: "newName")`. The fully AWS-spec-aligned declaration would be:

```graphql
directive @renamed(to: String!) on OBJECT | FIELD_DEFINITION
```

**This PR intentionally does not add the argument**, because doing so would be a breaking change: any existing user writing `@renamed` without an argument (which the current `directive @renamed on OBJECT` stub allows) would suddenly fail SDL validation with `Argument "to" of required type "String!" was not provided`. That fix should be addressed separately — likely behind a major-version bump or with a dedicated migration note. Mentioning it here so it isn't lost.

## Tests

`npx jest src/__tests__/schema.test.ts` → 6 passed (including the new test).
Full suite still passes for actual test files.

## Refs

- AWS Merged API best practices: https://aws.amazon.com/blogs/mobile/aws-appsync-merged-apis-best-practices-part-2-schema-composition/
- Mirror issue filed against Serverless Framework v4 (which embeds this plugin's source verbatim into `sf-core.js`): https://github.com/serverless/serverless/issues/13533

---
_This pull request is generated by a Claude Code Agent._