### PR TITLE
chore(deps): pin typescript to ~4.9 to block transitive major upgrades

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "serverless": "^3.25.1",
         "ts-jest": "^29.4.11",
         "ts-node": "^10.9.1",
-        "typescript": "^4.9.3"
+        "typescript": "~4.9.3"
       },
       "engines": {
         "node": ">=20.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "serverless": "^3.25.1",
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.3"
+    "typescript": "~4.9.3"
   },
   "dependencies": {
     "@graphql-tools/merge": "^8.3.12",


### PR DESCRIPTION
semantic-release@25 → cosmiconfig@9 declares typescript: '>=4.9.5', which npm's fresh dependency resolution was picking up as typescript@6.0.3. This caused dependabot PRs to fail CI on prepare-script tsc invocations.

Using ~ instead of ^ allows patch updates within 4.9.x while blocking accidental minor/major upgrades through transitive resolution. A future TypeScript 5.x upgrade will be a deliberate, separate PR.

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text.

Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->
## Proposed changes

Change `typescript: "^4.9.3"` → `typescript: "~4.9.3"` to prevent
semantic-release's transitive `typescript: ">=4.9.5"` (via cosmiconfig)
from resolving to TypeScript 6 during fresh lockfile resolution.

## Issue(s)

Unblocks Dependabot PR #697 and prevents the same failure on future
dependency PRs.

## Steps to test or reproduce

- `npm ci` succeeds without a `typescript@6` resolution error
- `npm test`, `npm run lint`, `npm run build` all pass (verified locally)

## Follow-up

After merging, comment `@dependabot rebase` on #697.
