### PR TITLE
feat(metrics): add enhanced metrics support Co-authored-by: Brendan D…

### DIFF
--- a/doc/enhancedMetrics.md
+++ b/doc/enhancedMetrics.md
@@ -1,0 +1,37 @@
+# Enhanced Metrics
+
+AppSync supports [Enhanced metrics](https://docs.aws.amazon.com/appsync/latest/devguide/monitoring.html#cw-metrics). You can configure them under the `appSync.enhancedMetrics` attribute.
+
+## Quick start
+
+```yaml
+appSync:
+  name: my-api
+  enhancedMetrics:
+    DataSourceLevelMetricsBehavior: 'FULL_REQUEST_DATA_SOURCE_METRICS'
+    OperationLevelMetricsConfig: 'ENABLED'
+    ResolverLevelMetricsBehavior: 'PER_RESOLVER_METRICS'
+```
+
+## Configuration
+
+All three properties are required by AWS. See the [official documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appsync-graphqlapi-enhancedmetricsconfig.html) for details.
+
+- `DataSourceLevelMetricsBehavior`: `FULL_REQUEST_DATA_SOURCE_METRICS` | `PER_DATA_SOURCE_METRICS`
+- `OperationLevelMetricsConfig`: `ENABLED` | `DISABLED`
+- `ResolverLevelMetricsBehavior`: `FULL_REQUEST_RESOLVER_METRICS` | `PER_RESOLVER_METRICS`
+
+## Per-resolver metrics
+
+When `ResolverLevelMetricsBehavior` is `PER_RESOLVER_METRICS`, AppSync only emits metrics for resolvers whose `MetricsConfig` is `ENABLED`. Set this per resolver with `metricsConfig`:
+
+```yaml
+appSync:
+  resolvers:
+    Query.user:
+      kind: UNIT
+      dataSource: my_table
+      metricsConfig: 'ENABLED'
+```
+
+`metricsConfig` defaults to `DISABLED` and is only emitted into the generated CloudFormation when `enhancedMetrics` is configured, so existing stacks that don't use enhanced metrics are unaffected. With `FULL_REQUEST_RESOLVER_METRICS`, metrics are emitted for all resolvers regardless of `metricsConfig`.

--- a/doc/general-config.md
+++ b/doc/general-config.md
@@ -46,6 +46,7 @@ appSync:
 - `pipelineFunctions`: See [Pipeline functions](pipeline-functions.md)
 - `substitutions`: See [Substitutions](substitutions.md). Deprecated: Use environment variables.
 - `environment`: A list of environment variables for the API. See [Official Documentation](https://docs.aws.amazon.com/appsync/latest/devguide/environment-variables.html)
+- `enhancedMetrics`: See [enhanced metrics](enhancedMetrics.md)
 - `caching`: See [Cacing](caching.md)
 - `waf`: See [Web Application Firefall](WAF.md)
 - `logging`: See [Logging](#Logging)

--- a/e2e/enhanced-metrics.e2e.test.ts
+++ b/e2e/enhanced-metrics.e2e.test.ts
@@ -1,0 +1,54 @@
+import { synthesize } from './helpers/synthesize';
+import {
+  getGraphQlApi,
+  findResourcesByType,
+  expectResourceWithProperties,
+} from './helpers/assertions';
+
+describe('examples/enhanced-metrics', () => {
+  let result: ReturnType<typeof synthesize>;
+
+  beforeAll(() => {
+    result = synthesize('examples/enhanced-metrics');
+  });
+
+  afterAll(() => {
+    result.cleanup();
+  });
+
+  it('emits a complete EnhancedMetricsConfig on the GraphQLApi', () => {
+    const { resource } = getGraphQlApi(result.template);
+    expect(resource.Properties?.EnhancedMetricsConfig).toEqual({
+      DataSourceLevelMetricsBehavior: 'PER_DATA_SOURCE_METRICS',
+      OperationLevelMetricsConfig: 'ENABLED',
+      ResolverLevelMetricsBehavior: 'PER_RESOLVER_METRICS',
+    });
+  });
+
+  it('defaults a resolver MetricsConfig to DISABLED', () => {
+    // Query.hello does not set metricsConfig
+    expectResourceWithProperties(result.template, 'AWS::AppSync::Resolver', {
+      FieldName: 'hello',
+      MetricsConfig: 'DISABLED',
+    });
+  });
+
+  it('honors a per-resolver metricsConfig override', () => {
+    // Query.user sets metricsConfig: ENABLED
+    expectResourceWithProperties(result.template, 'AWS::AppSync::Resolver', {
+      FieldName: 'user',
+      MetricsConfig: 'ENABLED',
+    });
+  });
+
+  it('emits MetricsConfig on every resolver when enhanced metrics are enabled', () => {
+    const resolvers = findResourcesByType(
+      result.template,
+      'AWS::AppSync::Resolver',
+    );
+    expect(resolvers.length).toBeGreaterThanOrEqual(2);
+    for (const { resource } of resolvers) {
+      expect(resource.Properties?.MetricsConfig).toBeDefined();
+    }
+  });
+});

--- a/examples/enhanced-metrics/schema.graphql
+++ b/examples/enhanced-metrics/schema.graphql
@@ -1,0 +1,4 @@
+type Query {
+  hello: String
+  user: String
+}

--- a/examples/enhanced-metrics/serverless.yml
+++ b/examples/enhanced-metrics/serverless.yml
@@ -1,0 +1,37 @@
+service: appsync-enhanced-metrics
+
+provider:
+  name: aws
+  runtime: nodejs22.x
+
+plugins:
+  - serverless-appsync-plugin
+
+appSync:
+  name: enhanced-metrics
+  authentication:
+    type: API_KEY
+  apiKeys:
+    - name: default
+
+  # Enhanced metrics emit granular CloudWatch data at the operation,
+  # data-source, and resolver levels. All three behaviors are required.
+  # With PER_RESOLVER_METRICS, only resolvers whose metricsConfig is
+  # ENABLED emit resolver-level metrics.
+  enhancedMetrics:
+    DataSourceLevelMetricsBehavior: 'PER_DATA_SOURCE_METRICS'
+    OperationLevelMetricsConfig: 'ENABLED'
+    ResolverLevelMetricsBehavior: 'PER_RESOLVER_METRICS'
+
+  resolvers:
+    Query.hello:
+      kind: UNIT
+      dataSource: none_ds
+    Query.user:
+      kind: UNIT
+      dataSource: none_ds
+      metricsConfig: 'ENABLED'
+
+  dataSources:
+    none_ds:
+      type: NONE

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -93,6 +93,39 @@ describe('Api', () => {
       `);
     });
 
+    it('should compile EnhancedMetricsConfig when configured', () => {
+      const api = new Api(
+        given.appSyncConfig({
+          enhancedMetrics: {
+            DataSourceLevelMetricsBehavior: 'FULL_REQUEST_DATA_SOURCE_METRICS',
+            OperationLevelMetricsConfig: 'ENABLED',
+            ResolverLevelMetricsBehavior: 'PER_RESOLVER_METRICS',
+          },
+        }),
+        plugin,
+      );
+      const props = (
+        api.compileEndpoint().GraphQlApi as {
+          Properties: Record<string, unknown>;
+        }
+      ).Properties;
+      expect(props.EnhancedMetricsConfig).toEqual({
+        DataSourceLevelMetricsBehavior: 'FULL_REQUEST_DATA_SOURCE_METRICS',
+        OperationLevelMetricsConfig: 'ENABLED',
+        ResolverLevelMetricsBehavior: 'PER_RESOLVER_METRICS',
+      });
+    });
+
+    it('should not emit EnhancedMetricsConfig when not configured', () => {
+      const api = new Api(given.appSyncConfig(), plugin);
+      const props = (
+        api.compileEndpoint().GraphQlApi as {
+          Properties: Record<string, unknown>;
+        }
+      ).Properties;
+      expect(props.EnhancedMetricsConfig).toBeUndefined();
+    });
+
     it('should compile the Api Resource with Environments', () => {
       const api = new Api(
         given.appSyncConfig({

--- a/src/__tests__/resolvers.test.ts
+++ b/src/__tests__/resolvers.test.ts
@@ -1142,4 +1142,60 @@ describe('Resolvers', () => {
       `);
     });
   });
+
+  describe('MetricsConfig', () => {
+    const baseResolver = {
+      dataSource: 'myTable',
+      kind: 'UNIT' as const,
+      type: 'Query',
+      field: 'user',
+      request: 'path/to/mappingTemplates/Query.user.request.vtl',
+      response: 'path/to/mappingTemplates/Query.user.response.vtl',
+    };
+
+    const enhancedMetrics = {
+      DataSourceLevelMetricsBehavior: 'PER_DATA_SOURCE_METRICS' as const,
+      OperationLevelMetricsConfig: 'ENABLED' as const,
+      ResolverLevelMetricsBehavior: 'PER_RESOLVER_METRICS' as const,
+    };
+
+    const dataSources = {
+      myTable: {
+        name: 'myTable',
+        type: 'AMAZON_DYNAMODB' as const,
+        config: { tableName: 'data' },
+      },
+    };
+
+    const getProps = (cfn: unknown) =>
+      Object.values(
+        cfn as Record<string, { Properties: Record<string, unknown> }>,
+      )[0].Properties;
+
+    it('omits MetricsConfig when enhanced metrics are not enabled', () => {
+      const api = new Api(given.appSyncConfig({ dataSources }), plugin);
+      const props = getProps(api.compileResolver(baseResolver));
+      expect('MetricsConfig' in props).toBe(false);
+    });
+
+    it('defaults resolver MetricsConfig to DISABLED when enhanced metrics are enabled', () => {
+      const api = new Api(
+        given.appSyncConfig({ dataSources, enhancedMetrics }),
+        plugin,
+      );
+      const props = getProps(api.compileResolver(baseResolver));
+      expect(props.MetricsConfig).toBe('DISABLED');
+    });
+
+    it('honors a per-resolver metricsConfig override', () => {
+      const api = new Api(
+        given.appSyncConfig({ dataSources, enhancedMetrics }),
+        plugin,
+      );
+      const props = getProps(
+        api.compileResolver({ ...baseResolver, metricsConfig: 'ENABLED' }),
+      );
+      expect(props.MetricsConfig).toBe('ENABLED');
+    });
+  });
 });

--- a/src/__tests__/validation/__snapshots__/base.test.ts.snap
+++ b/src/__tests__/validation/__snapshots__/base.test.ts.snap
@@ -29,6 +29,13 @@ exports[`Valdiation Domain Invalid should validate a useCloudFormation: not pres
 
 exports[`Valdiation Domain Invalid should validate a useCloudFormation: true, certificateArn or hostedZoneId is required 1`] = `"/domain: when using CloudFormation, you must provide either certificateArn or hostedZoneId."`;
 
+exports[`Valdiation EnhancedMetrics Invalid should validate a Bad value 1`] = `"/enhancedMetrics/OperationLevelMetricsConfig: must be 'ENABLED' or 'DISABLED'"`;
+
+exports[`Valdiation EnhancedMetrics Invalid should validate a Missing required field 1`] = `
+"/enhancedMetrics: must have required property 'DataSourceLevelMetricsBehavior'
+/enhancedMetrics: must have required property 'ResolverLevelMetricsBehavior'"
+`;
+
 exports[`Valdiation Log Invalid should validate a Invalid 1`] = `
 "/logging/level: must be one of 'ALL', 'INFO', 'DEBUG', 'ERROR' or 'NONE'
 /logging/retentionInDays: must be integer

--- a/src/__tests__/validation/base.test.ts
+++ b/src/__tests__/validation/base.test.ts
@@ -461,4 +461,62 @@ describe('Valdiation', () => {
       });
     });
   });
+
+  describe('EnhancedMetrics', () => {
+    describe('Valid', () => {
+      const assertions = [
+        {
+          name: 'Full',
+          config: {
+            ...basicConfig,
+            enhancedMetrics: {
+              DataSourceLevelMetricsBehavior:
+                'FULL_REQUEST_DATA_SOURCE_METRICS',
+              OperationLevelMetricsConfig: 'DISABLED',
+              ResolverLevelMetricsBehavior: 'PER_RESOLVER_METRICS',
+            },
+          } as AppSyncConfig,
+        },
+      ];
+
+      assertions.forEach((config) => {
+        it(`should validate a ${config.name}`, () => {
+          expect(validateConfig(config.config)).toBe(true);
+        });
+      });
+    });
+
+    describe('Invalid', () => {
+      const assertions = [
+        {
+          name: 'Missing required field',
+          config: {
+            ...basicConfig,
+            enhancedMetrics: {
+              OperationLevelMetricsConfig: 'ENABLED',
+            },
+          },
+        },
+        {
+          name: 'Bad value',
+          config: {
+            ...basicConfig,
+            enhancedMetrics: {
+              DataSourceLevelMetricsBehavior: 'PER_DATA_SOURCE_METRICS',
+              OperationLevelMetricsConfig: 'NOPE',
+              ResolverLevelMetricsBehavior: 'PER_RESOLVER_METRICS',
+            },
+          },
+        },
+      ];
+
+      assertions.forEach((config) => {
+        it(`should validate a ${config.name}`, () => {
+          expect(function () {
+            validateConfig(config.config);
+          }).toThrowErrorMatchingSnapshot();
+        });
+      });
+    });
+  });
 });

--- a/src/resources/Api.ts
+++ b/src/resources/Api.ts
@@ -112,6 +112,19 @@ export class Api {
       });
     }
 
+    if (this.config.enhancedMetrics) {
+      merge(endpointResource.Properties, {
+        EnhancedMetricsConfig: {
+          DataSourceLevelMetricsBehavior:
+            this.config.enhancedMetrics.DataSourceLevelMetricsBehavior,
+          OperationLevelMetricsConfig:
+            this.config.enhancedMetrics.OperationLevelMetricsConfig,
+          ResolverLevelMetricsBehavior:
+            this.config.enhancedMetrics.ResolverLevelMetricsBehavior,
+        },
+      });
+    }
+
     if (this.config.introspection !== undefined) {
       merge(endpointResource.Properties, {
         IntrospectionConfig: this.config.introspection ? 'ENABLED' : 'DISABLED',

--- a/src/resources/Resolver.ts
+++ b/src/resources/Resolver.ts
@@ -31,6 +31,15 @@ export class Resolver {
       FieldName: this.config.field,
     };
 
+    // Only emit MetricsConfig when enhanced metrics are enabled on the API.
+    // This keeps the generated CloudFormation unchanged for stacks that don't
+    // use enhanced metrics. When enabled, resolvers default to DISABLED (AWS's
+    // default) but can opt in per-resolver via `metricsConfig: ENABLED`, which
+    // is what makes ResolverLevelMetricsBehavior: PER_RESOLVER_METRICS useful.
+    if (this.api.config.enhancedMetrics) {
+      Properties.MetricsConfig = this.config.metricsConfig || 'DISABLED';
+    }
+
     const isVTLResolver = 'request' in this.config || 'response' in this.config;
     const isJsResolver =
       'code' in this.config || (!isVTLResolver && this.config.kind !== 'UNIT');

--- a/src/types/cloudFormation.ts
+++ b/src/types/cloudFormation.ts
@@ -117,6 +117,7 @@ export type CfnResolver = {
       };
     };
     MaxBatchSize?: number;
+    MetricsConfig?: 'ENABLED' | 'DISABLED';
   };
 };
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -132,6 +132,15 @@ export type SyncConfig = {
 
 export type Substitutions = Record<string, string | IntrinsicFunction>;
 export type EnvironmentVariables = Record<string, string | IntrinsicFunction>;
+export type EnhancedMetricsConfig = {
+  DataSourceLevelMetricsBehavior:
+    | 'FULL_REQUEST_DATA_SOURCE_METRICS'
+    | 'PER_DATA_SOURCE_METRICS';
+  OperationLevelMetricsConfig: 'ENABLED' | 'DISABLED';
+  ResolverLevelMetricsBehavior:
+    | 'FULL_REQUEST_RESOLVER_METRICS'
+    | 'PER_RESOLVER_METRICS';
+};
 
 export type DsDynamoDBConfig = {
   type: 'AMAZON_DYNAMODB';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,6 +61,7 @@ export type BaseResolverConfig = {
     | boolean;
   sync?: SyncConfig;
   substitutions?: Substitutions;
+  metricsConfig?: 'ENABLED' | 'DISABLED';
 };
 
 export type ResolverConfig = UnitResolverConfig | PipelineResolverConfig;

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -16,6 +16,7 @@ import {
   DsNone,
   Substitutions,
   EnvironmentVariables,
+  EnhancedMetricsConfig,
 } from './common';
 export * from './common';
 
@@ -31,6 +32,7 @@ export type AppSyncConfig = {
   pipelineFunctions: Record<string, PipelineFunctionConfig>;
   substitutions?: Substitutions;
   environment?: EnvironmentVariables;
+  enhancedMetrics?: EnhancedMetricsConfig;
   xrayEnabled?: boolean;
   logging?: LoggingConfig;
   caching?: CachingConfig;
@@ -57,6 +59,7 @@ export type BaseResolverConfig = {
     | boolean;
   sync?: SyncConfig;
   substitutions?: Substitutions;
+  metricsConfig?: 'ENABLED' | 'DISABLED';
 };
 
 export type ResolverConfig = UnitResolverConfig | PipelineResolverConfig;

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -288,6 +288,11 @@ export const appSyncSchema = {
         sync: { $ref: '#/definitions/syncConfig' },
         substitutions: { $ref: '#/definitions/substitutions' },
         caching: { $ref: '#/definitions/resolverCachingConfig' },
+        metricsConfig: {
+          type: 'string',
+          enum: ['ENABLED', 'DISABLED'],
+          errorMessage: "must be 'ENABLED' or 'DISABLED'",
+        },
       },
       if: { properties: { kind: { const: 'UNIT' } }, required: ['kind'] },
       then: {
@@ -810,6 +815,34 @@ export const appSyncSchema = {
         enabled: { type: 'boolean' },
       },
       required: ['level'],
+    },
+    enhancedMetrics: {
+      type: 'object',
+      properties: {
+        DataSourceLevelMetricsBehavior: {
+          type: 'string',
+          enum: ['FULL_REQUEST_DATA_SOURCE_METRICS', 'PER_DATA_SOURCE_METRICS'],
+          errorMessage:
+            "must be 'FULL_REQUEST_DATA_SOURCE_METRICS' or 'PER_DATA_SOURCE_METRICS'",
+        },
+        OperationLevelMetricsConfig: {
+          type: 'string',
+          enum: ['ENABLED', 'DISABLED'],
+          errorMessage: "must be 'ENABLED' or 'DISABLED'",
+        },
+        ResolverLevelMetricsBehavior: {
+          type: 'string',
+          enum: ['FULL_REQUEST_RESOLVER_METRICS', 'PER_RESOLVER_METRICS'],
+          errorMessage:
+            "must be 'FULL_REQUEST_RESOLVER_METRICS' or 'PER_RESOLVER_METRICS'",
+        },
+      },
+      required: [
+        'DataSourceLevelMetricsBehavior',
+        'OperationLevelMetricsConfig',
+        'ResolverLevelMetricsBehavior',
+      ],
+      additionalProperties: false,
     },
     dataSources: {
       oneOf: [


### PR DESCRIPTION
**Title:** `feat(metrics): add enhanced metrics support`

---

Supersedes #644. Original implementation by Brendan Doyle (@DoyleBrendan) — rebased onto current `master`, corrected, and extended with tests. Because the branch diverged significantly (109+ commits, plus a jest 27 → 30 bump on `master`), this is opened as a fresh PR rather than an in-place update; the original work is credited via a `Co-authored-by` trailer.

## What

Adds `appSync.enhancedMetrics`, which maps to the AppSync `EnhancedMetricsConfig` on `AWS::AppSync::GraphQLApi`, plus an optional per-resolver `metricsConfig` so resolver-level metrics can actually be enabled.

```yaml
appSync:
  name: my-api
  enhancedMetrics:
    DataSourceLevelMetricsBehavior: 'PER_DATA_SOURCE_METRICS'
    OperationLevelMetricsConfig: 'ENABLED'
    ResolverLevelMetricsBehavior: 'PER_RESOLVER_METRICS'
  resolvers:
    Query.user:
      kind: UNIT
      dataSource: my_table
      metricsConfig: 'ENABLED' # opt this resolver into metrics
```

## Correctness fixes on top of #644

- **`OperationLevelMetricsConfig` enum typo.** The original value was `' DISABLED'` (leading space) in both the type and the validation enum. AWS's value is `DISABLED`, so the correct value was rejected by validation while the space variant would fail at deploy — the disabled path was unusable. Fixed everywhere.
- **Required fields.** AWS marks all three `EnhancedMetricsConfig` properties as required, but the schema required none, so `enhancedMetrics: {}` passed validation and would synthesize an incomplete config that fails at deploy. The schema now requires all three (and disallows unknown keys).
- **`ResolverLevelMetricsBehavior` was ignored.** It was a required field in the public type but hardcoded to `PER_RESOLVER_METRICS` in the synthesized template. It's now honored from config.
- **Resolver `MetricsConfig` churn / non-functional feature.** The original stamped `MetricsConfig: 'DISABLED'` onto **every** resolver unconditionally — changing the CloudFormation for every existing user on their next deploy, and (with `PER_RESOLVER_METRICS` + always-`DISABLED`) making it impossible to ever enable resolver metrics. Now `MetricsConfig` is emitted only when `enhancedMetrics` is configured, defaults to `DISABLED`, and is overridable per resolver via the new `metricsConfig` field. Stacks that don't use enhanced metrics get byte-identical CloudFormation.

## New public config

- `resolvers.<Type>.<field>.metricsConfig`: `'ENABLED' | 'DISABLED'` (optional). Only emitted when `enhancedMetrics` is set. This is the only new public surface and the main thing to review — it's what makes `PER_RESOLVER_METRICS` meaningful.

## Tests

- **Unit:** API-level (`EnhancedMetricsConfig` emitted with all three values when set; absent otherwise), resolver-level (omitted without enhanced metrics; defaults to `DISABLED`; honors per-resolver override), and validation (valid full config; missing required field and bad value rejected).
- **e2e / CFN synthesis (offline):** new `examples/enhanced-metrics` fixture + `enhanced-metrics.e2e.test.ts` asserting the synthesized template contains a complete `EnhancedMetricsConfig` and the expected per-resolver `MetricsConfig` values.
- Local run: `npm run lint` clean, `npm test` (296 passing), `npm run test:e2e` (88 passing across 31 suites).

## Reviewer notes / not covered here

- Verified offline (CFN synthesis) only. A live `serverless deploy` is the final word on the in-place `EnhancedMetricsConfig` / `MetricsConfig` updates.
- Not smoke-tested on Serverless Framework v4.

Co-authored-by: Brendan Doyle <brendansdoyle@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AppSync now supports Enhanced Metrics configuration, enabling metrics tracking at data source, operation, and resolver levels
  * Support for per-resolver metrics override settings

* **Documentation**
  * Added comprehensive configuration guide for Enhanced Metrics with examples and reference values
  * New example project demonstrating Enhanced Metrics configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sid88in/serverless-appsync-plugin/pull/711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->