### PR TITLE
fix: allow CloudFormation intrinsic functions for config fields (#638)

### DIFF
--- a/src/__tests__/validation/__snapshots__/auth.test.ts.snap
+++ b/src/__tests__/validation/__snapshots__/auth.test.ts.snap
@@ -35,7 +35,7 @@ exports[`Valdiation Invalid should validate a Lambda with missing config 1`] = `
 exports[`Valdiation Invalid should validate a OIDC with empty config 1`] = `"/authentication/config: must have required property 'issuer'"`;
 
 exports[`Valdiation Invalid should validate a OIDC with invalid config 1`] = `
-"/authentication/config/issuer: must be string
+"/authentication/config/issuer: must be a string or a CloudFormation intrinsic function
 /authentication/config/clientId: must be string
 /authentication/config/iatTTL: must be number
 /authentication/config/authTTL: must be number"

--- a/src/__tests__/validation/__snapshots__/base.test.ts.snap
+++ b/src/__tests__/validation/__snapshots__/base.test.ts.snap
@@ -39,7 +39,7 @@ exports[`Valdiation EnhancedMetrics Invalid should validate a Missing required f
 exports[`Valdiation Log Invalid should validate a Invalid 1`] = `
 "/logging/level: must be one of 'ALL', 'INFO', 'DEBUG', 'ERROR' or 'NONE'
 /logging/retentionInDays: must be integer
-/logging/excludeVerboseContent: must be boolean"
+/logging/excludeVerboseContent: must be a boolean or a CloudFormation intrinsic function"
 `;
 
 exports[`Valdiation Waf Invalid should validate a Invalid 1`] = `
@@ -64,7 +64,7 @@ exports[`Valdiation should validate  1`] = `
 ": must have required property 'name'
 : must have required property 'authentication'
 /unknownPorp: invalid (unknown) property
-/xrayEnabled: must be boolean
+/xrayEnabled: must be a boolean or a CloudFormation intrinsic function
 /visibility: must be "GLOBAL" or "PRIVATE"
 /introspection: must be boolean
 /queryDepthLimit: must be integer

--- a/src/__tests__/validation/auth.test.ts
+++ b/src/__tests__/validation/auth.test.ts
@@ -76,6 +76,19 @@ describe('Valdiation', () => {
         } as AppSyncConfig,
       },
       {
+        name: 'OIDC with an intrinsic function issuer',
+        config: {
+          ...basicConfig,
+          authentication: {
+            type: 'OPENID_CONNECT',
+            config: {
+              issuer: { 'Fn::ImportValue': 'IssuerUrl' },
+              clientId: '90941906-004b-4cc5-9685-6864a8e08835',
+            },
+          },
+        } as AppSyncConfig,
+      },
+      {
         name: 'IAM',
         config: {
           ...basicConfig,

--- a/src/__tests__/validation/base.test.ts
+++ b/src/__tests__/validation/base.test.ts
@@ -49,6 +49,15 @@ describe('Valdiation', () => {
     }).toThrowErrorMatchingSnapshot();
   });
 
+  it('should allow intrinsic functions for xrayEnabled', () => {
+    expect(
+      validateConfig({
+        ...basicConfig,
+        xrayEnabled: { 'Fn::ImportValue': 'XrayEnabled' },
+      } as AppSyncConfig),
+    ).toBe(true);
+  });
+
   describe('Log', () => {
     describe('Valid', () => {
       const assertions = [
@@ -70,6 +79,16 @@ describe('Valdiation', () => {
               retentionInDays: 14,
               excludeVerboseContent: true,
               loggingRoleArn: { Ref: 'MyLogGorupArn' },
+            },
+          } as AppSyncConfig,
+        },
+        {
+          name: 'Intrinsic excludeVerboseContent',
+          config: {
+            ...basicConfig,
+            logging: {
+              level: 'ALL',
+              excludeVerboseContent: { 'Fn::ImportValue': 'ExcludeVerbose' },
             },
           } as AppSyncConfig,
         },

--- a/src/types/cloudFormation.ts
+++ b/src/types/cloudFormation.ts
@@ -16,7 +16,16 @@ export type FnSub = {
   'Fn::Sub': [string, Record<string, string | IntrinsicFunction>];
 };
 
-export type IntrinsicFunction = FnGetAtt | FnJoin | FnRef | FnSub;
+export type FnImportValue = {
+  'Fn::ImportValue': string | IntrinsicFunction;
+};
+
+export type IntrinsicFunction =
+  | FnGetAtt
+  | FnJoin
+  | FnRef
+  | FnSub
+  | FnImportValue;
 
 export type CfnDeltaSyncConfig = {
   BaseTableTTL: number;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -100,7 +100,7 @@ export type LambdaAuth = {
 export type OidcAuth = {
   type: 'OPENID_CONNECT';
   config: {
-    issuer: string;
+    issuer: string | IntrinsicFunction;
     clientId: string;
     iatTTL?: number;
     authTTL?: number;
@@ -243,7 +243,7 @@ export type VisibilityConfig = {
 export type LoggingConfig = {
   level: 'ERROR' | 'NONE' | 'ALL' | 'DEBUG' | 'INFO';
   enabled?: boolean;
-  excludeVerboseContent?: boolean;
+  excludeVerboseContent?: boolean | IntrinsicFunction;
   retentionInDays?: number;
   roleArn?: string | IntrinsicFunction;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 import { BuildOptions } from 'esbuild';
+import { IntrinsicFunction } from './cloudFormation';
 import {
   ApiKeyConfig,
   Auth,
@@ -35,7 +36,7 @@ export type AppSyncConfig = {
     | Record<string, DataSourceConfig>;
   substitutions?: Substitutions;
   environment?: EnvironmentVariables;
-  xrayEnabled?: boolean;
+  xrayEnabled?: boolean | IntrinsicFunction;
   logging?: LoggingConfig;
   caching?: CachingConfig;
   waf?: WafConfig;

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,4 +1,5 @@
 import { BuildOptions } from 'esbuild';
+import { IntrinsicFunction } from './cloudFormation';
 import {
   Auth,
   DomainConfig,
@@ -33,7 +34,7 @@ export type AppSyncConfig = {
   substitutions?: Substitutions;
   environment?: EnvironmentVariables;
   enhancedMetrics?: EnhancedMetricsConfig;
-  xrayEnabled?: boolean;
+  xrayEnabled?: boolean | IntrinsicFunction;
   logging?: LoggingConfig;
   caching?: CachingConfig;
   waf?: WafConfig;

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -36,6 +36,17 @@ export const appSyncSchema = {
       ],
       errorMessage: 'must be a string or a CloudFormation intrinsic function',
     },
+    booleanOrIntrinsicFunction: {
+      oneOf: [
+        { type: 'boolean' },
+        {
+          type: 'object',
+          required: [],
+          additionalProperties: true,
+        },
+      ],
+      errorMessage: 'must be a boolean or a CloudFormation intrinsic function',
+    },
     mappingTemplate: {
       oneOf: [{ type: 'string' }, { const: false }],
       errorMessage:
@@ -133,7 +144,7 @@ export const appSyncSchema = {
     oidcAuth: {
       type: 'object',
       properties: {
-        issuer: { type: 'string' },
+        issuer: { $ref: '#/definitions/stringOrIntrinsicFunction' },
         clientId: { type: 'string' },
         iatTTL: { type: 'number' },
         authTTL: { type: 'number' },
@@ -699,7 +710,7 @@ export const appSyncSchema = {
           'when using CloudFormation, you must provide either certificateArn or hostedZoneId.',
       },
     },
-    xrayEnabled: { type: 'boolean' },
+    xrayEnabled: { $ref: '#/definitions/booleanOrIntrinsicFunction' },
     visibility: {
       type: 'string',
       enum: ['GLOBAL', 'PRIVATE'],
@@ -820,7 +831,9 @@ export const appSyncSchema = {
             "must be one of 'ALL', 'INFO', 'DEBUG', 'ERROR' or 'NONE'",
         },
         retentionInDays: { type: 'integer' },
-        excludeVerboseContent: { type: 'boolean' },
+        excludeVerboseContent: {
+          $ref: '#/definitions/booleanOrIntrinsicFunction',
+        },
         enabled: { type: 'boolean' },
       },
       required: ['level'],


### PR DESCRIPTION
# Enable CloudFormation intrinsic functions for config fields

Fixes #638. Revives #640 (original work by @ronnyroeller).

## Background

Before the v2 rewrite, several `appSync` config values could be set to CloudFormation intrinsic functions (`Fn::Join`, `Fn::ImportValue`, `Ref`, etc.). v2's stricter schema validation locked these fields to primitive `boolean`/`string` types, so configs like this stopped resolving:

```ts
openIdConnectConfig: {
  issuer: {
    'Fn::Join': ['', ['https://', { 'Fn::ImportValue': 'IssuerDomain' }]],
  },
}
```

…failing with `at appSync/.../issuer: must be string`.

## What this changes

Restores intrinsic-function support for the config values that are passed **straight through to the generated CloudFormation template**:

- `openIdConnectConfig.issuer`
- `xrayEnabled`
- `logging.excludeVerboseContent`

Implementation:

- Adds a `booleanOrIntrinsicFunction` schema definition, mirroring the existing `stringOrIntrinsicFunction`.
- Points the three fields at the appropriate `oneOf` definition and widens the corresponding TypeScript types (`boolean | IntrinsicFunction` / `string | IntrinsicFunction`).
- No resource-generation changes needed — these values were already written through unchanged, and the validation snapshots now read `must be a boolean/string or a CloudFormation intrinsic function`.

## Intentionally **not** included

`waf.enabled`, `logging.enabled`, `caching.enabled`, and `domain.enabled` remain plain booleans. These are **synth-time toggles** — the plugin checks `=== false` in JS to decide whether to generate the resource at all, so a deploy-time intrinsic can't drive them. Accepting one would pass validation but silently always-create the resource, which would be worse than the current clear error.

## Tests

- Added validation cases asserting intrinsic functions are accepted for `xrayEnabled`, `openIdConnectConfig.issuer`, and `logging.excludeVerboseContent`.
- Existing negative cases still fail correctly (a plain string for `xrayEnabled`, a number for `issuer`, etc.).
- Full suite green: `npm test` (334), `npm run test:e2e` (84), `npm run lint` (0 errors), `npm run build`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration now accepts CloudFormation intrinsic functions for OIDC issuer, X-Ray enablement, and logging exclusion flags.

* **Tests**
  * Added tests covering validation of intrinsic-function values for those configuration fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->