### PR TITLE
fix: allow false for resolver request/response mapping templates (#598)

### DIFF
--- a/src/__tests__/validation/__snapshots__/resolvers.test.ts.snap
+++ b/src/__tests__/validation/__snapshots__/resolvers.test.ts.snap
@@ -6,8 +6,8 @@ exports[`Basic Invalid should validate: Invalid 1`] = `
 /resolvers/myResolver/type: must be string
 /resolvers/myResolver/field: must be string
 /resolvers/myResolver/maxBatchSize: must be <= 2000
-/resolvers/myResolver/request: must be string
-/resolvers/myResolver/response: must be string
+/resolvers/myResolver/request: must be a string (path to the template) or false to omit the mapping template
+/resolvers/myResolver/response: must be a string (path to the template) or false to omit the mapping template
 /resolvers: contains invalid resolver definitions"
 `;
 
@@ -18,6 +18,12 @@ exports[`Basic Invalid should validate: Invalid datasource 1`] = `
 
 exports[`Basic Invalid should validate: Invalid embedded datasource 1`] = `
 "/resolvers/Query.getUser/dataSource/config: must specify functionName, functionArn or function (all exclusives)
+/resolvers: contains invalid resolver definitions"
+`;
+
+exports[`Basic Invalid should validate: Mapping template true (only string or false allowed) 1`] = `
+"/resolvers/Query.user/request: must be a string (path to the template) or false to omit the mapping template
+/resolvers/Query.user/response: must be a string (path to the template) or false to omit the mapping template
 /resolvers: contains invalid resolver definitions"
 `;
 

--- a/src/__tests__/validation/resolvers.test.ts
+++ b/src/__tests__/validation/resolvers.test.ts
@@ -76,6 +76,25 @@ describe('Basic', () => {
         },
       },
       {
+        name: 'Disabled mapping templates (request/response: false)',
+        config: {
+          resolvers: {
+            'Query.noTemplates': {
+              kind: 'UNIT',
+              dataSource: 'myDs',
+              request: false,
+              response: false,
+            },
+            'Query.onlyResponse': {
+              kind: 'UNIT',
+              dataSource: 'myDs',
+              request: false,
+              response: 'response.vtl',
+            },
+          },
+        },
+      },
+      {
         name: 'Valid config, as array of maps',
         config: {
           resolvers: [
@@ -147,6 +166,19 @@ describe('Basic', () => {
               request: 123,
               response: 456,
               maxBatchSize: 5000,
+            },
+          },
+        },
+      },
+      {
+        name: 'Mapping template true (only string or false allowed)',
+        config: {
+          resolvers: {
+            'Query.user': {
+              kind: 'UNIT',
+              dataSource: 'myDs',
+              request: true,
+              response: true,
             },
           },
         },

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -36,6 +36,11 @@ export const appSyncSchema = {
       ],
       errorMessage: 'must be a string or a CloudFormation intrinsic function',
     },
+    mappingTemplate: {
+      oneOf: [{ type: 'string' }, { const: false }],
+      errorMessage:
+        'must be a string (path to the template) or false to omit the mapping template',
+    },
     lambdaFunctionConfig: {
       oneOf: [
         {
@@ -283,8 +288,8 @@ export const appSyncSchema = {
         field: { type: 'string' },
         maxBatchSize: { type: 'number', minimum: 1, maximum: 2000 },
         code: { type: 'string' },
-        request: { type: 'string' },
-        response: { type: 'string' },
+        request: { $ref: '#/definitions/mappingTemplate' },
+        response: { $ref: '#/definitions/mappingTemplate' },
         sync: { $ref: '#/definitions/syncConfig' },
         substitutions: { $ref: '#/definitions/substitutions' },
         caching: { $ref: '#/definitions/resolverCachingConfig' },


### PR DESCRIPTION
# Fix resolver `request`/`response` validation to allow `false`

Fixes #598.

## Problem

The resolver config type allows the mapping templates to be `false`:

```ts
export type BaseResolverConfig = {
  // ...
  request?: string | false;
  response?: string | false;
};
```

…but the validation schema only accepts strings, so a config like `request: false` is rejected before it ever reaches the resolver compiler:

```
at appSync/.../request: must be string
```

This is a type-vs-validation mismatch: the type (and the compiler) support `false`, but validation does not.

## Why `false` is a real feature

The resolver compiler already handles `false` correctly:

- `isVTLResolver = 'request' in this.config || 'response' in this.config` — setting `request: false` still puts the resolver on the VTL path (rather than being treated as a JS resolver), and
- `resolveMappingTemplate()` does `const templateName = this.config[type]; if (templateName) { … }` — with `false`, that's falsy, so the corresponding `RequestMappingTemplate` / `ResponseMappingTemplate` simply isn't emitted.

So `false` is a deliberate way to declare a VTL resolver that omits a request and/or response mapping template. Only the schema was out of sync.

## Change

- Adds a `mappingTemplate` schema definition: `oneOf: [{ type: 'string' }, { const: false }]`, with a clear error message.
- Points `resolverConfig.request` / `resolverConfig.response` at it.
- No type changes were needed — the types already declared `string | false`; this brings validation in line with them.

The validation error message changes from `must be string` to `must be a string (path to the template) or false to omit the mapping template`, which the existing negative-case snapshot reflects.

## Out of scope (intentional)

Pipeline functions (`PipelineFunctionConfig`) keep `request`/`response` as `string`-only. There the type **and** the schema already agree (both string-only), so there's no mismatch to fix; adding `false` there would be a separate feature change (type + schema) rather than a bug fix.

## Tests

- Added a valid case: a UNIT resolver with `request: false` / `response: false`, and one with `request: false` + a response template path.
- Added an invalid case: `request: true` / `response: true` is rejected (guards against widening to any boolean).
- Existing negative case (`request: 123`) still fails, with the updated message.
- Full suite green: `npm test` (333), `npm run test:e2e` (84), `npm run lint` (0 errors), `npm run build`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resolver configuration validation now supports optional mapping templates, allowing them to be disabled with `false` in addition to specifying template paths.

* **Tests**
  * Expanded validation test suite with cases for resolver configurations with disabled mapping templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->