### PR TITLE
fix: strip redeclared AWS directives and scalars from schema (#590)

### DIFF
--- a/src/__tests__/fixtures/schemas/reserved/schema.graphql
+++ b/src/__tests__/fixtures/schemas/reserved/schema.graphql
@@ -1,0 +1,12 @@
+directive @aws_cognito_user_pools on OBJECT | FIELD_DEFINITION
+
+scalar AWSJSON
+
+type Query {
+  getAccount: Account
+}
+
+type Account @aws_cognito_user_pools {
+  id: ID!
+  metadata: AWSJSON
+}

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -207,6 +207,28 @@ describe('schema', () => {
     expect(() => api.compileSchema()).not.toThrow();
   });
 
+  it('should accept and strip schemas that redeclare AWS directives/scalars', () => {
+    const api = new Api(
+      given.appSyncConfig({
+        schema: ['src/__tests__/fixtures/schemas/reserved/schema.graphql'],
+      }),
+      plugin,
+    );
+    // Previously threw: There can be only one directive named "@aws_cognito_user_pools".
+    expect(() => api.compileSchema()).not.toThrow();
+
+    const output = new Schema(api, [
+      'src/__tests__/fixtures/schemas/reserved/schema.graphql',
+    ]).generateSchema();
+
+    // The redeclarations are removed (AppSync provides them)...
+    expect(output).not.toMatch(/directive @aws_cognito_user_pools/);
+    expect(output).not.toMatch(/scalar AWSJSON/);
+    // ...but their usage is preserved.
+    expect(output).toContain('@aws_cognito_user_pools');
+    expect(output).toContain('AWSJSON');
+  });
+
   it('should return single files schemas as-is', () => {
     const api = new Api(given.appSyncConfig(), plugin);
     const schema = new Schema(api, [

--- a/src/resources/Schema.ts
+++ b/src/resources/Schema.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { CfnResources } from '../types/cloudFormation';
 import { Api } from './Api';
 import { flatten } from 'lodash';
-import { parse, print } from 'graphql';
+import { parse, print, Kind, DefinitionNode } from 'graphql';
 import { validateSDL } from 'graphql/validation/validate';
 import { mergeTypeDefs } from '@graphql-tools/merge';
 
@@ -31,6 +31,27 @@ scalar AWSURL
 scalar AWSPhone
 scalar AWSIPAddress
 `;
+
+// The directive and scalar names AppSync provides itself (derived from
+// AWS_TYPES so the two never drift). User schemas that redeclare any of these
+// — often to satisfy a schema linter — must have the redeclaration stripped,
+// otherwise validation sees a duplicate definition and AppSync rejects the
+// upload.
+const reservedNames = ((): {
+  directives: Set<string>;
+  types: Set<string>;
+} => {
+  const directives = new Set<string>();
+  const types = new Set<string>();
+  for (const def of parse(AWS_TYPES).definitions) {
+    if (def.kind === Kind.DIRECTIVE_DEFINITION) {
+      directives.add(def.name.value);
+    } else if ('name' in def && def.name) {
+      types.add(def.name.value);
+    }
+  }
+  return { directives, types };
+})();
 
 export class Schema {
   constructor(private api: Api, private schemas: string[]) {}
@@ -71,12 +92,12 @@ export class Schema {
     );
 
     const schemas = schemaFiles.map((file) => {
-      return fs.readFileSync(file, 'utf8');
+      return this.stripReservedDefinitions(fs.readFileSync(file, 'utf8'));
     });
 
     this.valdiateSchema(AWS_TYPES + '\n' + schemas.join('\n'));
 
-    // Return single files as-is.
+    // Return single (already stripped) files as-is.
     if (schemas.length === 1) {
       return schemas[0];
     }
@@ -93,4 +114,31 @@ export class Schema {
       }),
     );
   }
+
+  // AppSync provides its own directives (@aws_*, plus the plugin's merge
+  // directives) and scalars (AWSJSON, AWSDateTime, ...). Users sometimes also
+  // declare them — e.g. to satisfy a schema linter — which collides with the
+  // definitions we prepend for validation and is rejected by AppSync on
+  // deploy. Strip any such redeclaration, leaving the original text untouched
+  // when there is nothing to remove.
+  stripReservedDefinitions(schema: string): string {
+    const doc = parse(schema);
+    const definitions = doc.definitions.filter(
+      (def) => !isReservedDefinition(def),
+    );
+    if (definitions.length === doc.definitions.length) {
+      return schema;
+    }
+    return print({ ...doc, definitions });
+  }
+}
+
+function isReservedDefinition(def: DefinitionNode): boolean {
+  if (def.kind === Kind.DIRECTIVE_DEFINITION) {
+    return reservedNames.directives.has(def.name.value);
+  }
+  if ('name' in def && def.name) {
+    return reservedNames.types.has(def.name.value);
+  }
+  return false;
 }


### PR DESCRIPTION
# Strip redeclared AWS directives & scalars from the schema

Fixes #590.

## Problem

Before validating, the plugin prepends `AWS_TYPES` — which declares the AppSync directives (`@aws_iam`, `@aws_oidc`, `@aws_api_key`, `@aws_lambda`, `@aws_auth`, `@aws_cognito_user_pools`, `@aws_subscribe`, plus the merge directives `@canonical`/`@hidden`/`@renamed`) and the AppSync scalars (`AWSJSON`, `AWSDateTime`, …) — to the user's schema:

```ts
this.valdiateSchema(AWS_TYPES + '\n' + schemas.join('\n'));
```

If the user's own schema also declares any of those (commonly required to satisfy a schema linter such as `graphql-eslint`), validation sees the definition twice and fails:

```
Invalid GraphQL schema:
     There can be only one directive named "@aws_cognito_user_pools".
```

The same applies to `@aws_iam` / `@aws_api_key` / `@aws_oidc` and to redeclared scalars. There's also a second layer: AppSync rejects an uploaded schema that redeclares its built-in directives/scalars, so even past validation the deploy would fail.

## Fix

Strip any user definition that AppSync already provides, before both validation and output:

- The reserved directive/scalar names are derived from `AWS_TYPES` itself (so the two never drift).
- `stripReservedDefinitions()` parses each schema and drops `DirectiveDefinition`s / scalar definitions whose name is reserved. **Only the redeclaration (the definition) is removed — every *usage* is preserved.**
- To stay non-disruptive, a schema with nothing to strip is returned byte-for-byte unchanged (no reparse/reprint, so existing formatting and comments are untouched).

This lets users keep the directive/scalar declarations in their source for linting while the plugin transparently removes them for AppSync.

## Tests

- New fixture `fixtures/schemas/reserved/schema.graphql` redeclares `@aws_cognito_user_pools` and `scalar AWSJSON` and uses both.
- New test asserts the schema compiles without throwing, the redeclarations are absent from the output, and the usages remain.
- All existing schema snapshots are unchanged (current fixtures only *use*, never *declare*, the reserved names, so they hit the byte-for-byte passthrough).
- Full suite green: `npm test` (332), `npm run test:e2e` (84), `npm run lint` (0 errors), `npm run build`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved duplicate-definition errors when using AWS reserved GraphQL directives and scalars in schemas.

* **Tests**
  * Added comprehensive test coverage for schema compilation with reserved directive redeclarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->