### PR TITLE
fix(waf): set OversizeHandling on disableIntrospection body matches

### DIFF
--- a/src/__tests__/__snapshots__/waf.test.ts.snap
+++ b/src/__tests__/__snapshots__/waf.test.ts.snap
@@ -70,7 +70,9 @@ exports[`Waf ApiKey rules should generate a rule for disableIntrospection 1`] = 
                   "SizeConstraintStatement": {
                     "ComparisonOperator": "GT",
                     "FieldToMatch": {
-                      "Body": {},
+                      "Body": {
+                        "OversizeHandling": "MATCH",
+                      },
                     },
                     "Size": 8192,
                     "TextTransformations": [
@@ -84,7 +86,9 @@ exports[`Waf ApiKey rules should generate a rule for disableIntrospection 1`] = 
                 {
                   "ByteMatchStatement": {
                     "FieldToMatch": {
-                      "Body": {},
+                      "Body": {
+                        "OversizeHandling": "CONTINUE",
+                      },
                     },
                     "PositionalConstraint": "CONTAINS",
                     "SearchString": "__schema",
@@ -446,7 +450,9 @@ exports[`Waf Disable introspection should generate a preset rule 1`] = `
           "SizeConstraintStatement": {
             "ComparisonOperator": "GT",
             "FieldToMatch": {
-              "Body": {},
+              "Body": {
+                "OversizeHandling": "MATCH",
+              },
             },
             "Size": 8192,
             "TextTransformations": [
@@ -460,7 +466,9 @@ exports[`Waf Disable introspection should generate a preset rule 1`] = `
         {
           "ByteMatchStatement": {
             "FieldToMatch": {
-              "Body": {},
+              "Body": {
+                "OversizeHandling": "CONTINUE",
+              },
             },
             "PositionalConstraint": "CONTAINS",
             "SearchString": "__schema",
@@ -497,7 +505,9 @@ exports[`Waf Disable introspection should generate a preset rule with custon con
           "SizeConstraintStatement": {
             "ComparisonOperator": "GT",
             "FieldToMatch": {
-              "Body": {},
+              "Body": {
+                "OversizeHandling": "MATCH",
+              },
             },
             "Size": 8192,
             "TextTransformations": [
@@ -511,7 +521,9 @@ exports[`Waf Disable introspection should generate a preset rule with custon con
         {
           "ByteMatchStatement": {
             "FieldToMatch": {
-              "Body": {},
+              "Body": {
+                "OversizeHandling": "CONTINUE",
+              },
             },
             "PositionalConstraint": "CONTAINS",
             "SearchString": "__schema",

--- a/src/__tests__/waf.test.ts
+++ b/src/__tests__/waf.test.ts
@@ -142,6 +142,32 @@ describe('Waf', () => {
         ),
       ).toMatchSnapshot();
     });
+
+    it('sets OversizeHandling on the body field matches (required by WAF)', () => {
+      const rule = waf.buildWafRule('disableIntrospection', 'Base');
+
+      // FieldToMatch is intentionally loosely typed in production, so narrow
+      // to the shape this assertion cares about.
+      type BodyMatch = { FieldToMatch: { Body: { OversizeHandling: string } } };
+      const { Statements } = rule.Statement.OrStatement as unknown as {
+        Statements: {
+          SizeConstraintStatement?: BodyMatch;
+          ByteMatchStatement?: BodyMatch;
+        }[];
+      };
+
+      // The size guard must MATCH oversized bodies, otherwise bodies larger
+      // than the 8kb inspection limit are never blocked.
+      expect(
+        Statements[0].SizeConstraintStatement?.FieldToMatch.Body
+          .OversizeHandling,
+      ).toBe('MATCH');
+      // The __schema lookup inspects the available body and lets the size
+      // guard handle anything oversized.
+      expect(
+        Statements[1].ByteMatchStatement?.FieldToMatch.Body.OversizeHandling,
+      ).toBe('CONTINUE');
+    });
   });
 
   describe('Custom rules', () => {

--- a/src/resources/Waf.ts
+++ b/src/resources/Waf.ts
@@ -252,7 +252,13 @@ export class Waf {
               SizeConstraintStatement: {
                 ComparisonOperator: 'GT',
                 FieldToMatch: {
-                  Body: {},
+                  // AppSync only forwards the first 8kb of the body to WAF,
+                  // so an oversized body must be treated as a match in order
+                  // to actually block it (CONTINUE would cap the measured
+                  // size at the inspection limit and never exceed it).
+                  Body: {
+                    OversizeHandling: 'MATCH',
+                  },
                 },
                 Size: 8 * 1024,
                 TextTransformations: [
@@ -266,7 +272,12 @@ export class Waf {
             {
               ByteMatchStatement: {
                 FieldToMatch: {
-                  Body: {},
+                  // Inspect the available (first 8kb) body for the
+                  // introspection query. Larger bodies are caught by the
+                  // SizeConstraintStatement above.
+                  Body: {
+                    OversizeHandling: 'CONTINUE',
+                  },
                 },
                 PositionalConstraint: 'CONTAINS',
                 SearchString: '__schema',


### PR DESCRIPTION
## What

Add the now-required `OversizeHandling` setting to the body field matches in the built-in `disableIntrospection` WAF rule, so that Web ACL create/update operations no longer fail.

Closes #573.

## Why

AWS WAF made oversize handling mandatory for any rule that inspects the request body. ACLs that inspect the body without it now fail with `WafConfigurationWarningException`:

> The operation failed because you are inspecting the web request body, headers, or cookies without specifying how to handle oversize components. Rules that inspect the body must either provide an `OversizeHandling` configuration or they must be preceded by a `SizeConstraintStatement` that blocks the body content from being too large.

The plugin's auto-generated `disableIntrospection` rule inspects `Body` in two statements and set neither, so every WAF deployment that uses it now breaks (the reporter was warned this would start failing after 2023-03-31).

## The fix

The rule is an `OrStatement` of two body inspections, and they need **different** oversize behavior:

- **`ByteMatchStatement`** (search the body for `__schema`) → `OversizeHandling: CONTINUE`. Inspect the available body (first 8 KB) for the introspection query. Anything hidden beyond the inspection window is caught by the size guard below.
- **`SizeConstraintStatement`** (`Body` size `GT` 8 KB) → `OversizeHandling: MATCH`. For AppSync the body inspection limit is fixed at 8 KB, so the host only forwards the first 8 KB to WAF. With `CONTINUE`, the measured size would be capped at 8 KB and `GT 8192` could never be true — silently disabling the oversized-body guard and letting a large body smuggle `__schema` past the inspection window. `MATCH` treats an oversized body as a match, which (via the `Or` + `Block` action) blocks it. This is the documented "block large payloads" pattern.

This preserves the rule's original two-pronged protection while making it compliant. No source change was needed to the public `Body: {}` shape elsewhere; only the built-in rule is affected.

## Out of scope (intentional)

The issue floated making oversize handling user-configurable "like `Name` and `Priority`." I deliberately did **not** expose a single knob: the two statements require different values for correctness (`MATCH` vs `CONTINUE`), so a single user-facing option would be a footgun — e.g. setting `CONTINUE` on the size guard re-introduces the smuggling gap. The reporter also noted a sensible default is sufficient ("a default of Continue can be applied in line with the AWS default"); this PR ships correct defaults instead. A configurable option can be revisited separately if a concrete need arises.

The API-key WAF rules are unaffected: they inspect a `SingleHeader` (`X-Api-key`), which is not an oversize-able component and takes no `OversizeHandling`.

## Testing

- Updated the three affected snapshots; the diff is limited to the added `OversizeHandling` keys (`MATCH` on each `SizeConstraintStatement` body, `CONTINUE` on each `ByteMatchStatement` body).
- Added an explicit-value unit test asserting `MATCH` on the size guard and `CONTINUE` on the `__schema` lookup, so a future snapshot update can't silently flip these to an incorrect value.
- Gates: `npm run build`, `npm run lint` (0 errors), `npm test` (332 passing), `npm run test:e2e` (84 passing) all pass.

## Confidence

- The `OversizeHandling` requirement, the AppSync 8 KB body limit, and the `MATCH`-vs-`CONTINUE` semantics are **verified** against AWS WAF documentation.
- I could **not** exercise this against a live WAF deployment from this environment; the verification is offline synthesis plus the documented AWS behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced introspection protection in WAF rules to properly handle oversized request bodies—now correctly blocks oversized requests while allowing evaluation of larger bodies for introspection detection.

* **Tests**
  * Added test coverage for introspection rule oversize handling behavior across size-constraint and byte-match statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->