### PR TITLE
fix(cli): clear error for intrinsic certificateArn in domain commands

### DIFF
--- a/doc/custom-domain.md
+++ b/doc/custom-domain.md
@@ -51,6 +51,8 @@ For example, if you want to use blue/green deployments, you might need to associ
 
 For more information about managing domains with the CLI, see the [Commands](commands.md#domain) section.
 
+⚠️ The CLI commands resolve values themselves rather than through CloudFormation, so `certificateArn` must be a literal ARN string when using them. CloudFormation intrinsic functions (e.g. `Fn::ImportValue`) are only resolved when the domain is managed by CloudFormation (`useCloudFormation: true`).
+
 ## Ejecting from CloudFormation
 
 If you started to manage your domain through CloudFormation and want to eject from it, follow the following steps:

--- a/src/__tests__/commands.test.ts
+++ b/src/__tests__/commands.test.ts
@@ -93,6 +93,32 @@ describe('create domain', () => {
     `);
   });
 
+  it('should reject an intrinsic-function certificateArn (CLI cannot resolve it)', async () => {
+    mockSend.mockResolvedValue({});
+
+    await expect(
+      runServerless({
+        fixture: 'appsync',
+        command: 'appsync domain create',
+        configExt: {
+          appSync: {
+            domain: {
+              useCloudFormation: false,
+              certificateArn: { 'Fn::ImportValue': 'exportedCertArn' },
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      /the `appsync domain` CLI commands require a plain ARN string/,
+    );
+
+    const createCall = mockSend.mock.calls.find(
+      ([cmd]) => cmd instanceof CreateDomainNameCommand,
+    );
+    expect(createCall).toBeUndefined();
+  });
+
   it('should create a domain and find a matching certificate, exact match', async () => {
     mockSend.mockImplementation((cmd) => {
       if (cmd instanceof ListCertificatesCommand) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -715,6 +715,14 @@ class ServerlessAppsyncPlugin {
         );
       }
 
+      if (typeof certificateArn !== 'string') {
+        throw new this.serverless.classes.Error(
+          `Invalid \`certificateArn\`: the \`appsync domain\` CLI commands require a plain ARN string. ` +
+            `CloudFormation intrinsic functions (e.g. Fn::ImportValue) can only be resolved by CloudFormation, not by the CLI. ` +
+            `Either pass a literal ARN, or manage the domain through CloudFormation (the default, \`domain.useCloudFormation: true\`), where the intrinsic function will be resolved.`,
+        );
+      }
+
       await this.clientFactory.getAppSyncClient().send(
         new CreateDomainNameCommand({
           domainName: domain.name,

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -119,7 +119,7 @@ export type DomainConfig = {
   useCloudFormation?: boolean;
   retain?: boolean;
   name: string;
-  certificateArn?: string;
+  certificateArn?: string | IntrinsicFunction;
   hostedZoneId?: string;
   hostedZoneName?: string;
   route53?: boolean;


### PR DESCRIPTION
## What

Give a clear, actionable error when a CloudFormation intrinsic function (e.g. `Fn::ImportValue`) is passed as `domain.certificateArn` to the `appsync domain` **CLI** commands, instead of the cryptic SDK error `Expected params.certificateArn to be a string`.

Closes #532.

## Why

`domain.certificateArn` is validated as `stringOrIntrinsicFunction`, which accepts any object — intentionally, because in the **CloudFormation** path the value is written straight into the `AWS::AppSync::DomainName` resource, where an intrinsic like `Fn::ImportValue` is valid and gets resolved at deploy time.

The **CLI** path is different. `createDomain()` calls the AppSync SDK's `CreateDomainNameCommand` directly, which needs a resolved string ARN. There is no CloudFormation context to resolve an intrinsic client‑side, so passing one currently fails deep in the SDK with `Expected params.certificateArn to be a string` — which gives the user no hint about the actual problem (as reported in #532).

This is the CloudFormation‑passthrough vs. CLI/synth‑time distinction: an intrinsic `certificateArn` is meaningful only for values written through to the template, not for a value the CLI must hand to the SDK.

## The fix

- `createDomain()` (`src/index.ts`): after resolving `certificateArn`, throw a plugin error if it is not a string, explaining that the CLI requires a literal ARN and that intrinsic functions are only resolved via the CloudFormation integration (the default `domain.useCloudFormation: true`). The check sits before the SDK call, so we fail fast with guidance instead of a SDK type error.
- `DomainConfig.certificateArn` type (`src/types/common.ts`): widened from `string` to `string | IntrinsicFunction` to match what validation actually accepts. This also makes the runtime guard type‑meaningful (it narrows the union) and matches the convention used for other intrinsic‑capable fields in the codebase. (`IntrinsicFunction` is already imported in this file.)
- Docs (`doc/custom-domain.md`): a note in the "Using CloudFormation vs the CLI commands" section that the CLI requires a literal ARN and that intrinsic functions are only resolved when the domain is managed by CloudFormation.

## What this does NOT change (intentional)

- Validation still accepts an intrinsic `certificateArn` — that is correct for the CloudFormation path and must not be tightened.
- The CloudFormation synthesis path is untouched: an imported/intrinsic ARN continues to flow into the `AWS::AppSync::DomainName` `CertificateArn` property and is resolved by CloudFormation. So the real answer to "how do I use an imported cert ARN?" — use the CloudFormation integration — keeps working; this PR just makes the CLI fail clearly instead of cryptically.
- `IntrinsicFunction` is not broadened to add `Fn::ImportValue` (it currently models `Fn::GetAtt`/`Fn::Join`/`Ref`/`Fn::Sub`). That's a pre‑existing, separate limitation; validation already accepts any object at runtime, and the new guard catches every non‑string regardless of the exact union, so the fix is correct without touching the shared type.

## Testing

- Added a negative unit test: `appsync domain create` with `certificateArn: { 'Fn::ImportValue': ... }` and `useCloudFormation: false` rejects with the new message, and `CreateDomainNameCommand` is never sent.
- The existing positive create tests (literal ARN, ACM exact/wildcard match) still pass unchanged.
- Gates: `npm run build`, `npm run lint` (0 errors), `npm test` (332 passing), `npm run test:e2e` (84 passing), and `prettier --check doc/custom-domain.md` all pass.

## Confidence

- The CLI‑vs‑CloudFormation behavior is verified against the source paths (`createDomain` → SDK vs `compileCustomDomain` → template) and the validation schema.
- I could not exercise the live SDK error string from this environment; the new error is thrown by the plugin before the SDK call, so it does not depend on the SDK's wording. Live AWS resolution of an imported ARN via the CloudFormation path is unchanged but was not deployed from here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification that custom domains managed via CLI require a literal ARN string for certificates, not CloudFormation intrinsic functions.

* **Bug Fixes**
  * CLI now validates that certificate ARN values are plain strings and rejects CloudFormation functions with a helpful error message directing users to enable CloudFormation-based domain management if needed.

* **Tests**
  * Added test coverage for certificate ARN validation in CLI domain creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->