### PR TITLE
docs: document AppSync per-item cache eviction (evictFromApiCache)

### DIFF
--- a/doc/caching.md
+++ b/doc/caching.md
@@ -28,6 +28,50 @@ appSync:
 
 See [Resolver caching](resolvers.md#caching)
 
+## Evicting items from the cache
+
+To evict a single entry from the cache (rather than flushing everything), use AppSync's [`evictFromApiCache`](https://docs.aws.amazon.com/appsync/latest/devguide/extensions.html) extension from within a resolver. This is a runtime feature of AppSync, so there is nothing special to configure in this plugin: just call it from the mapping template or JavaScript code of the resolver, and it is passed through to AppSync as-is.
+
+A few things to keep in mind (see the [AppSync docs](https://docs.aws.amazon.com/appsync/latest/devguide/enabling-caching.html) for the details):
+
+- It only works in **mutation** resolvers, not queries.
+- The target entry is identified by the type name, field name, and a map of caching keys. The keys must match — in the same order — the `keys` of the cached resolver you want to evict.
+
+For example, given a cached query resolver:
+
+```yaml
+appSync:
+  resolvers:
+    Query.getNote:
+      dataSource: notes
+      caching:
+        ttl: 60
+        keys:
+          - '$context.arguments.id'
+```
+
+You can evict its cached entry from a mutation resolver. With a VTL response template:
+
+```vtl
+#set($keys = {})
+$util.qr($keys.put("context.arguments.id", $ctx.args.id))
+$extensions.evictFromApiCache("Query", "getNote", $keys)
+$util.toJson($ctx.result)
+```
+
+Or with a JavaScript resolver:
+
+```js
+import { extensions } from '@aws-appsync/utils';
+
+export function response(ctx) {
+  extensions.evictFromApiCache('Query', 'getNote', {
+    'context.arguments.id': ctx.args.id,
+  });
+  return ctx.result;
+}
+```
+
 ## Flushing the cache
 
 You can use the [flush-cache command](commands.md#flush-cache) to easily flush the cache.


### PR DESCRIPTION
## What

Document AWS AppSync's per-item cache eviction (`evictFromApiCache`) in `doc/caching.md`, with VTL and JavaScript examples.

Closes #502.

## Why

#502 asks the plugin to "support cache eviction" ([AWS item-eviction feature](https://aws.amazon.com/blogs/mobile/introducing-server-side-caching-item-eviction-for-aws-appsync/)).

There's nothing for the plugin to implement: `$extensions.evictFromApiCache(...)` (VTL) / `extensions.evictFromApiCache(...)` (JS, from `@aws-appsync/utils`) is a **runtime** AppSync utility called from within a resolver's mapping template or JS code. It is not a CloudFormation/config property — AppSync evaluates it at request time. The plugin already passes resolver templates and JS code through to AppSync verbatim, and already supports the one prerequisite (per-resolver caching with `keys`). So eviction has effectively been usable all along; it just wasn't discoverable from the plugin's docs.

This PR closes that gap by adding an "Evicting items from the cache" section to the caching guide.

## What's in it

A new section in `doc/caching.md` (between "Per resolver caching" and "Flushing the cache") that:

- Explains eviction is a runtime feature, so no plugin-specific config is needed — you call it from a resolver.
- Notes the two constraints from the AWS docs: it only works in **mutation** resolvers, and the eviction key map must match the cached resolver's `keys` in the same order.
- Shows a cached query resolver in plugin config, then how to evict its entry from a mutation resolver with both a VTL response template and a JavaScript resolver.
- Links to the AWS extensions / caching docs for the precise rules.

## Out of scope (intentional)

No code change. There is no sensible plugin abstraction to add here — eviction is inherently per-resolver runtime logic that lives in the user's template/code, which the plugin already passes through. Whole-cache flushing already exists via the `flush-cache` command and is cross-referenced from the same page.

## Testing

Docs-only; `prettier --check doc/caching.md` passes. No source/tests touched, so `build` / `lint` / `test` / `test:e2e` are unaffected. The VTL and JS snippets mirror AWS's own published examples.

## Confidence

- The mechanics (runtime utility, mutation-only, key-order matching, callable from request/response template or JS) are verified against the AWS AppSync extensions and caching documentation.
- Not exercised against a live cached API from this environment; the examples follow AWS's documented usage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation on how to remove cached resolver entries from AppSync, including examples for VTL and JavaScript resolvers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->