### PR TITLE
fix(schema): support absolute schema paths

### DIFF
--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import { Api } from '../resources/Api';
 import { Schema } from '../resources/Schema';
 import * as given from './given';
@@ -227,6 +228,29 @@ describe('schema', () => {
     // ...but their usage is preserved.
     expect(output).toContain('@aws_cognito_user_pools');
     expect(output).toContain('AWSJSON');
+  });
+
+  it('should support absolute schema paths regardless of servicePath', () => {
+    const plugin = given.plugin();
+    // servicePath deliberately points somewhere the schema is NOT;
+    // an absolute schema path must still be read correctly.
+    plugin.serverless.config.servicePath = path.resolve('does', 'not', 'exist');
+    const api = new Api(given.appSyncConfig(), plugin);
+    const absolutePath = path.resolve(
+      'src/__tests__/fixtures/schemas/single/schema.graphql',
+    );
+    const schema = new Schema(api, [absolutePath]);
+    expect(schema.generateSchema()).toContain('type Query');
+  });
+
+  it('should resolve relative schema paths against servicePath', () => {
+    const plugin = given.plugin();
+    plugin.serverless.config.servicePath = process.cwd();
+    const api = new Api(given.appSyncConfig(), plugin);
+    const schema = new Schema(api, [
+      'src/__tests__/fixtures/schemas/single/schema.graphql',
+    ]);
+    expect(schema.generateSchema()).toContain('type Query');
   });
 
   it('should return single files schemas as-is', () => {

--- a/src/resources/Schema.ts
+++ b/src/resources/Schema.ts
@@ -85,7 +85,10 @@ export class Schema {
       globby.sync(
         this.schemas.map((schema) =>
           path
-            .join(this.api.plugin.serverless.config.servicePath, schema)
+            // `path.resolve` keeps relative paths resolved against the
+            // service directory while leaving absolute paths untouched
+            // (`path.join` would incorrectly prefix them with servicePath).
+            .resolve(this.api.plugin.serverless.config.servicePath, schema)
             .replace(/\\/g, '/'),
         ),
       ),


### PR DESCRIPTION
# fix(schema): support absolute `schema` paths

Closes #382

## Problem

`schema` file paths were resolved with `path.join(servicePath, schema)`. `path.join`
treats every argument as a segment, so an **absolute** schema path gets incorrectly
prefixed with the service directory:

```js
path.join('/svc/path', '/abs/schema.graphql')
// => '/svc/path/abs/schema.graphql'   (file not found)
```

The result is that an absolute `schema` path silently resolves to nothing: globbing
returns no files and an empty schema is produced. This is the exact limitation reported
in #382 (originally against the v1 `get-config.js`), and it is still present on the v2
line in `src/resources/Schema.ts`.

## Fix

Use `path.resolve` instead of `path.join`:

```js
path.resolve('/svc/path', 'schema.graphql')      // => '/svc/path/schema.graphql'  (unchanged for relative)
path.resolve('/svc/path', '/abs/schema.graphql') // => '/abs/schema.graphql'        (absolute honored)
```

`path.resolve` keeps the existing behaviour for relative paths (resolved against the
service directory) while leaving absolute paths untouched. This is the one-line change
proposed by the reporter, applied to the current code location. Glob expansion,
schema stitching, and the Windows-path handling (`.replace(/\\/g, '/')`) are all
unaffected.

> Note: #382 also asked about glob support (`schema: schemas/*.graphql`). That is
> already implemented on the v2 line (`globby` + `@graphql-tools/merge`), so this PR
> only addresses the remaining absolute-path gap.

## Tests

Added two cases to `src/__tests__/schema.test.ts`:

- **`should support absolute schema paths regardless of servicePath`** — sets
  `servicePath` to a directory that does *not* contain the schema and passes an
  absolute path to a fixture; asserts the schema is still read. (Fails on `master`:
  `generateSchema()` returns `""`.)
- **`should resolve relative schema paths against servicePath`** — regression guard
  confirming relative paths still resolve against the service directory.

The existing relative-path / glob / stitching snapshots are unchanged.

## Verification

- `npm run build` — OK
- `npm run lint` — 0 errors
- `npm test` — 21 suites / 347 tests pass; 216 snapshots unchanged
- `npm run test:e2e` — 31 suites / 90 tests pass

Verified the patch applies cleanly to a fresh `origin/master` (`978c4cb`) and that the
schema suite (10 tests) passes there after `npm ci && npm run build`.

## Credit

The fix approach (`join` → `resolve`) was proposed by @ankon in #382. I have not added a
`Co-authored-by:` trailer because I don't have a verified commit email for them — happy to
add one if you'd like to attribute it that way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema file path resolution to correctly handle both absolute and relative schema paths relative to the service directory.

* **Tests**
  * Added test coverage validating schema path resolution for absolute and relative paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->