### PR TITLE
fix(datasources): use AWS::Partition in generated ARNs

### DIFF
--- a/src/__tests__/__snapshots__/dataSources.test.ts.snap
+++ b/src/__tests__/__snapshots__/dataSources.test.ts.snap
@@ -319,7 +319,9 @@ exports[`DataSource DynamoDB should generate Resource with default deltaSync 1`]
                             ":",
                             [
                               "arn",
-                              "aws",
+                              {
+                                "Ref": "AWS::Partition",
+                              },
                               "dynamodb",
                               {
                                 "Ref": "AWS::Region",
@@ -344,7 +346,9 @@ exports[`DataSource DynamoDB should generate Resource with default deltaSync 1`]
                             ":",
                             [
                               "arn",
-                              "aws",
+                              {
+                                "Ref": "AWS::Partition",
+                              },
                               "dynamodb",
                               {
                                 "Ref": "AWS::Region",
@@ -449,7 +453,9 @@ exports[`DataSource DynamoDB should generate Resource with default role 1`] = `
                             ":",
                             [
                               "arn",
-                              "aws",
+                              {
+                                "Ref": "AWS::Partition",
+                              },
                               "dynamodb",
                               {
                                 "Ref": "AWS::Region",
@@ -474,7 +480,9 @@ exports[`DataSource DynamoDB should generate Resource with default role 1`] = `
                             ":",
                             [
                               "arn",
-                              "aws",
+                              {
+                                "Ref": "AWS::Partition",
+                              },
                               "dynamodb",
                               {
                                 "Ref": "AWS::Region",
@@ -581,7 +589,9 @@ exports[`DataSource DynamoDB should generate default role with a Ref for the tab
                             ":",
                             [
                               "arn",
-                              "aws",
+                              {
+                                "Ref": "AWS::Partition",
+                              },
                               "dynamodb",
                               {
                                 "Ref": "AWS::Region",
@@ -608,7 +618,9 @@ exports[`DataSource DynamoDB should generate default role with a Ref for the tab
                             ":",
                             [
                               "arn",
-                              "aws",
+                              {
+                                "Ref": "AWS::Partition",
+                              },
                               "dynamodb",
                               {
                                 "Ref": "AWS::Region",
@@ -713,7 +725,9 @@ exports[`DataSource DynamoDB should generate default role with custom region 1`]
                             ":",
                             [
                               "arn",
-                              "aws",
+                              {
+                                "Ref": "AWS::Partition",
+                              },
                               "dynamodb",
                               "us-east-2",
                               {
@@ -736,7 +750,9 @@ exports[`DataSource DynamoDB should generate default role with custom region 1`]
                             ":",
                             [
                               "arn",
-                              "aws",
+                              {
+                                "Ref": "AWS::Partition",
+                              },
                               "dynamodb",
                               "us-east-2",
                               {
@@ -1190,7 +1206,9 @@ exports[`DataSource OpenSearch should generate Resource with endpoint 1`] = `
                       ":",
                       [
                         "arn",
-                        "aws",
+                        {
+                          "Ref": "AWS::Partition",
+                        },
                         "es",
                         "us-east-1",
                         {
@@ -1432,7 +1450,9 @@ exports[`DataSource Relational Databases should generate Resource with default r
               ":",
               [
                 "arn",
-                "aws",
+                {
+                  "Ref": "AWS::Partition",
+                },
                 "rds",
                 {
                   "Ref": "AWS::Region",
@@ -1497,7 +1517,9 @@ exports[`DataSource Relational Databases should generate Resource with default r
                       ":",
                       [
                         "arn",
-                        "aws",
+                        {
+                          "Ref": "AWS::Partition",
+                        },
                         "rds",
                         {
                           "Ref": "AWS::Region",
@@ -1519,7 +1541,9 @@ exports[`DataSource Relational Databases should generate Resource with default r
                             ":",
                             [
                               "arn",
-                              "aws",
+                              {
+                                "Ref": "AWS::Partition",
+                              },
                               "rds",
                               {
                                 "Ref": "AWS::Region",

--- a/src/__tests__/dataSources.test.ts
+++ b/src/__tests__/dataSources.test.ts
@@ -6,6 +6,24 @@ const plugin = given.plugin();
 
 describe('DataSource', () => {
   describe('DynamoDB', () => {
+    // Regression guard for #352: generated resource ARNs must derive the
+    // partition from CloudFormation (`AWS::Partition`) so they are valid in
+    // the aws-cn (China) and aws-us-gov (GovCloud) partitions, not hardcoded
+    // to "aws".
+    it('should derive the resource ARN partition from AWS::Partition', () => {
+      const api = new Api(given.appSyncConfig(), plugin);
+      const dataSource = new DataSource(api, {
+        type: 'AMAZON_DYNAMODB',
+        name: 'dynamo',
+        config: {
+          tableName: 'data',
+        },
+      });
+      const role = JSON.stringify(dataSource.compileDataSourceIamRole());
+      expect(role).toContain('"Ref":"AWS::Partition"');
+      expect(role).not.toContain('"arn","aws"');
+    });
+
     it('should generate Resource with default role', () => {
       const api = new Api(given.appSyncConfig(), plugin);
       const dataSource = new DataSource(api, {

--- a/src/resources/DataSource.ts
+++ b/src/resources/DataSource.ts
@@ -146,7 +146,7 @@ export class DataSource {
             ':',
             [
               'arn',
-              'aws',
+              { Ref: 'AWS::Partition' },
               'rds',
               config.config.region || { Ref: 'AWS::Region' },
               { Ref: 'AWS::AccountId' },
@@ -277,7 +277,7 @@ export class DataSource {
             ':',
             [
               'arn',
-              'aws',
+              { Ref: 'AWS::Partition' },
               'dynamodb',
               this.config.config.region || { Ref: 'AWS::Region' },
               { Ref: 'AWS::AccountId' },
@@ -324,7 +324,7 @@ export class DataSource {
             ':',
             [
               'arn',
-              'aws',
+              { Ref: 'AWS::Partition' },
               'rds',
               this.config.config.region || { Ref: 'AWS::Region' },
               { Ref: 'AWS::AccountId' },
@@ -380,7 +380,7 @@ export class DataSource {
               ':',
               [
                 'arn',
-                'aws',
+                { Ref: 'AWS::Partition' },
                 'es',
                 result[2],
                 { Ref: 'AWS::AccountId' },


### PR DESCRIPTION
# fix(datasources): use `AWS::Partition` in generated ARNs (China / GovCloud)

Closes #352

## Problem

The default IAM policy / config ARNs synthesized for data sources hardcode the `aws`
partition. In the `aws-cn` (China: `cn-north-1`, `cn-northwest-1`) and `aws-us-gov`
(GovCloud) partitions this produces invalid ARNs and deployment fails, e.g.:

```
Partition "aws" is not valid for resource "arn:aws:dynamodb:cn-north-1:1234:table/ddbTable".
```

The ARNs are built with `Fn::Join` where the partition segment is the literal string
`'aws'` (so it isn't obvious from a text search for `arn:aws:`). This affects four sites in
`src/resources/DataSource.ts`:

- DynamoDB data-source role policy resource ARN
- Relational database (RDS) data-source role policy resource ARN
- Relational database `RdsHttpEndpointConfig.DbClusterIdentifier` ARN
- OpenSearch data-source role policy resource ARN (endpoint form)

(Reported originally against the v1 `src/index.js`; the same hardcoding carried into v2.)

## Fix

Replace the hardcoded `'aws'` partition segment with the CloudFormation pseudo-parameter
`{ Ref: 'AWS::Partition' }` in all four `Fn::Join` ARN constructions. CloudFormation resolves
`AWS::Partition` to the correct partition (`aws` / `aws-cn` / `aws-us-gov`) for the deployment
region, so the ARNs are valid everywhere.

Lambda data sources are unaffected: their ARNs already come from `Fn::GetAtt`/passthrough
(`Api.generateLambdaArn`), which are partition-correct.

This mirrors the existing intrinsic-function style in the same arrays (which already use
`{ Ref: 'AWS::Region' }` and `{ Ref: 'AWS::AccountId' }`).

## Tests

- Added a regression test (`dataSources.test.ts` → DynamoDB): asserts the generated role
  ARN contains `{ Ref: 'AWS::Partition' }` and never the hardcoded `["arn","aws"...]`.
- Updated the `dataSources` snapshots. The diff is **only** `"aws"` → `{ "Ref":
  "AWS::Partition" }` (10 occurrences across 6 snapshots); no other changes.

## Verification

- `npm run build` — OK
- `npm run lint` — 0 errors
- `npm test` — 21 suites / 348 tests pass; 216 snapshots
- `npm run test:e2e` — 31 suites / 90 tests pass

Verified the patch applies cleanly to a fresh `origin/master` (`978c4cb`) and that the
`dataSources` suite (26 tests) passes there after `npm ci && npm run build`.

## Note

Verified via offline CloudFormation synthesis only — the sandbox can't deploy to a real
China/GovCloud account. The change is a straightforward swap to the standard partition
pseudo-parameter, which is the documented AWS-recommended approach for partition-agnostic
ARNs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated IAM role policies for DynamoDB, RDS, and OpenSearch data sources to dynamically reference AWS partition values instead of using hardcoded partition identifiers.

* **Tests**
  * Added test to verify correct IAM role policy generation for DynamoDB data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->