### PR TITLE
fix: failing to get correct region when it is configured with variables

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,7 @@ type ServerlessPluginUtils = {
 
 class ServerlessAppsyncPlugin {
   private provider: Provider;
-  private clientFactory: AwsClientFactory;
+  private _clientFactory?: AwsClientFactory;
   private gatheredData: {
     apis: {
       id: string;
@@ -152,16 +152,6 @@ class ServerlessAppsyncPlugin {
     this.provider = this.serverless.getProvider('aws');
     this.utils = utils;
 
-    // Resolve region and credentials the same way the Serverless Framework
-    // does for its own AWS calls, so the live commands honor the --region /
-    // --aws-profile CLI options, provider.region / provider.profile from the
-    // service config, and any assumed-role / environment credentials. Falling
-    // back to the bare default credential chain (as a plain
-    // `fromNodeProviderChain()` would) silently ignores all of the above and
-    // breaks profile-based and multi-account setups.
-    const region = this.provider.getRegion();
-    const credentials = resolveCredentials(this.provider);
-    this.clientFactory = new AwsClientFactory(region, credentials);
     // We are using a newer version of AJV than Serverless Framework
     // and some customizations (eg: custom errors, $merge, filter irrelevant errors)
     // For SF, just validate the type of input to allow us to use a custom
@@ -1058,6 +1048,32 @@ class ServerlessAppsyncPlugin {
     if (!conceal) {
       this.serverless.addServiceOutputSection('appsync api keys', apiKeys);
     }
+  }
+
+  /**
+   * AWS client factory, built lazily on first access.
+   *
+   * Region and credentials are resolved the same way the Serverless Framework
+   * does for its own AWS calls, so the live commands honor the --region /
+   * --aws-profile CLI options, provider.region / provider.profile from the
+   * service config, and any assumed-role / environment credentials. Falling
+   * back to the bare default credential chain (as a plain
+   * `fromNodeProviderChain()` would) silently ignores all of the above and
+   * breaks profile-based and multi-account setups.
+   *
+   * Resolution is deferred to first use (inside command / deploy hooks) rather
+   * than the constructor: Serverless instantiates plugins before it resolves
+   * `${...}` variables, so resolving the region eagerly would capture the
+   * literal unresolved string (eg: `${opt:region, param:provider_region}`) and
+   * bake it into the SDK client => "Region not accepted".
+   */
+  private get clientFactory(): AwsClientFactory {
+    if (!this._clientFactory) {
+      const region = this.provider.getRegion();
+      const credentials = resolveCredentials(this.provider);
+      this._clientFactory = new AwsClientFactory(region, credentials);
+    }
+    return this._clientFactory;
   }
 
   loadConfig() {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text.

Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

## Proposed changes

Defer loading of the region until Serverless has resolved the configuration. 
https://www.serverless.com/framework/docs/guides/plugins/creating-plugins#serverless-instance

<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
-->

## Issue(s)

This fixes an issue introduced in version 2.11 that stops the region configuration from being loaded properly. 

<!-- Link the issues being closed by or related to this PR. For example, you can use #333 if this PR closes issue number 333 -->

## Steps to test or reproduce

<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. -->
Trying to run `serverless deploy` with a configuration like below will fail because the region is invalid.

```
provider:
  name: aws
  region: ${opt:region, param:provider_region}
params:
  default:
    provider_region: eu-west-1

  prod:
    provider_region: eu-central-1
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin startup behavior by delaying cloud configuration lookup until it is actually needed.
  * Reduced the chance of initialization issues when region or credentials are not immediately available.
  * This should make deploy and command execution more reliable in environments with deferred AWS setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->