### PR TITLE
fix(security): force external-editor's tmp to >=0.2.6 (CVE-2026-44705)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16425,16 +16425,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -20002,16 +19992,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
     },
     "serverless": {
       "tar": "^7.5.8"
+    },
+    "external-editor": {
+      "tmp": "^0.2.6"
     }
   },
   "dependencies": {


### PR DESCRIPTION
# fix(security): force `external-editor`'s `tmp` to `>=0.2.6`

Addresses **Dependabot alert 247** — `tmp` path traversal via unsanitized `prefix`/`postfix`.

> **No `Fixes #N` trailer:** Dependabot alert numbers and issue numbers are separate namespaces —
> `Fixes #247` would link to an unrelated issue. The advisory is referenced by GHSA ID instead.

## Summary

One-line scoped override lifting the `tmp` under `external-editor` from `0.0.33` to `0.2.7`.

```diff
   "serverless": {
     "tar": "^7.5.8"
+  },
+  "external-editor": {
+    "tmp": "^0.2.6"
   }
```

## The advisory

**CVE-2026-44705 / GHSA-ph9p-34f9-6g65** — High (7.7), CWE-22. Affected `tmp < 0.2.6`; patched `0.2.6`.

`tmp` composes paths as `path.join(tmpDir, opts.dir, '<prefix>-<pid>-<random>-<postfix>')` with no containment check. `path.join()` normalizes `../` sequences, so traversal in `prefix`, `postfix`, or `dir` escapes the temp directory and creates files at attacker-chosen locations with the process's privileges.

## Why Dependabot can't auto-fix it

Dependabot reports it *cannot* update: `external-editor@3.1.0` pins `tmp@^0.0.33`, which is semver-incompatible with the `0.2.6` fix. The chain is:

```
devDependencies → all-contributors-cli@6.26.1 → inquirer@7.3.3 → external-editor@3.1.0 → tmp@0.0.33
```

Bumping `all-contributors-cli` doesn't help: `6.26.1` is already the latest stable and still depends on `inquirer@^7.3.3`. So the only route is a **scoped override** across the major boundary — which requires proving `external-editor` survives the jump.

## Why the major bump is safe

`external-editor` calls exactly **one** `tmp` API:

```js
// external-editor/main/index.js:131
this.tempFile = tmp_1.tmpNameSync(this.fileOptions);
```

`tmp@0.2.x` still exports `tmpNameSync` (alongside `file`, `fileSync`, `dir`, `dirSync`, `tmpName`, `setGracefulCleanup`). Verified functionally against `tmp@0.2.7`:

- `tmpNameSync({})`, `tmpNameSync({postfix:'.txt'})`, `tmpNameSync({prefix:'ec',postfix:'.md'})` — all the option shapes `inquirer` / `external-editor` pass — return correctly.
- `new ExternalEditor('hello')` instantiates, creates its temp file, and `cleanup()` succeeds.
- `all-contributors --version` / `--help` still run (`6.26.1`).

## Verified actually fixed

The advisory's own PoC, run against both versions:

| | `tmp@0.0.33` (master) | `tmp@0.2.7` (this PR) |
|---|---|---|
| `prefix: '../../escaped'` | `/escaped902XoCeldgMRxIc` — **escaped to `/`** | rejected: `Relative value not allowed` |
| `postfix: '/../../pwned.txt'` | `/pwned.txt` — **escaped to `/`** | rejected: `Relative value not allowed` |

## Result

Verified against current `master` (`b48496b`):

- `tmp@0.2.7`, marked `overridden` (`was "^0.0.33"`) — single copy in the tree.
- **Clears 4 advisories**: `tmp` (high), plus `external-editor`, `inquirer`, and `all-contributors-cli`, which were flagged only because they depend on vulnerable `tmp`. Master: 16 advisories → this branch: 12.
- **No regressions** — advisory-set diff introduces nothing new.
- `tmp` was never in the production tree, so plugin consumers were never exposed; this clears dev-tree alerts.
- `npm ci` succeeds (lockfile in sync), `npm run build`, `npm run lint` (0 errors), `npm run test` (**360 passing, 21 suites**) all green.
- Tiny lockfile diff (~17 deletions): `tmp@0.0.33`'s `os-tmpdir` dependency drops away.

## To apply

```bash
npm pkg set 'overrides.external-editor.tmp=^0.2.6'
npm install     # regenerates package-lock.json

npm run build && npm run lint && npm test
npm ls tmp      # expect tmp@0.2.7 overridden
npm audit       # no tmp findings
node node_modules/.bin/all-contributors --version   # CLI still runs
```

## Notes

- **Override is scoped to `external-editor`**, its direct parent, rather than applied globally. `external-editor` is the only consumer of `tmp` in the tree, so the effect is identical today, but the scoped form documents intent and won't silently capture a future unrelated `tmp` consumer.
- **`all-contributors-cli` is not wired into any npm script or workflow** — it's run ad hoc against `.all-contributorsrc`. Removing it entirely (as with `semantic-release` in #740) would also clear these alerts, but it's a tool you actually use, so overriding is the less disruptive fix. Worth revisiting if the `inquirer@7` chain accumulates more advisories.
- Remaining `npm audit` findings (`decompress`, `js-yaml`, `undici`, …) are dev-only advisories from `serverless` / `@serverless/test` / `semantic-release`, tracked separately (`undici` and `npm` are cleared by #740).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated a dependency constraint to help ensure more reliable app behavior and reduce issues related to temporary file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->